### PR TITLE
Update to graphql-java v12 + required modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>neo4j-graphql-java</artifactId>
     <name>Neo4j GraphQL Java</name>
     <description>GraphQL to Cypher Mapping</description>
-    <version>1.0.0-M02</version>
+    <version>1.0.0-M03</version>
     <url>http://github.com/neo4j-contrib/neo4j-tinkerpop-api</url>
 
     <licenses>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>5.0</version>
+            <version>12.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -10,15 +10,15 @@ fun GraphQLType.inner() : GraphQLType = when(this) {
 }
 val SCALAR_TYPES = listOf("String","ID","Boolean","Int","Float")
 
-fun Type.isScalar() = this.inner().name()?.let { SCALAR_TYPES.contains(it) } ?: false
-fun Type.name() : String? = if (this.inner() is TypeName) (this.inner() as TypeName).name else null
+fun Type<Type<*>>.isScalar() = this.inner().name()?.let { SCALAR_TYPES.contains(it) } ?: false
+fun Type<Type<*>>.name() : String? = if (this.inner() is TypeName) (this.inner() as TypeName).name else null
 
-fun Type.inner() : Type = when(this) {
+fun Type<Type<*>>.inner() : Type<Type<*>> = when(this) {
     is ListType -> this.type.inner()
     is NonNullType -> this.type.inner()
     else -> this
 }
-fun Type.render(nonNull:Boolean = true) : String = when(this) {
+fun Type<Type<*>>.render(nonNull:Boolean = true) : String = when(this) {
     is ListType -> "[${this.type.render()}]"
     is NonNullType -> this.type.render()+ (if (nonNull) "!" else "")
     is TypeName -> this.name
@@ -56,7 +56,7 @@ fun Directive.argumentString(name:String, schema:GraphQLSchema) : String {
             ?: throw IllegalStateException("No default value for ${this.name}.${name}")
 }
 
-fun Value.toCypherString(): String = when (this) {
+fun Value<Value<*>>.toCypherString(): String = when (this) {
     is StringValue -> "'"+this.value+"'"
     is EnumValue -> "'"+this.name+"'"
     is NullValue -> "null"
@@ -68,7 +68,7 @@ fun Value.toCypherString(): String = when (this) {
     else -> throw IllegalStateException("Unhandled value "+this)
 }
 
-fun Value.toJavaValue(): Any? = when (this) {
+fun Value<Value<*>>.toJavaValue(): Any? = when (this) {
     is StringValue -> this.value
     is EnumValue -> this.name
     is NullValue -> null

--- a/src/main/kotlin/org/neo4j/graphql/Predicates.kt
+++ b/src/main/kotlin/org/neo4j/graphql/Predicates.kt
@@ -197,7 +197,7 @@ enum class Operators(val suffix:String, val op:String, val not :Boolean = false)
                 else listOf(EQ, NEQ, IN, NIN,LT,LTE,GT,GTE) +
                         if (type == Scalars.GraphQLString || type == Scalars.GraphQLID) listOf(C,NC, SW, NSW,EW,NEW) else emptyList()
 
-        fun forType(type: Type) : List<Operators> =
+        fun forType(type: Type<Type<*>>) : List<Operators> =
                 if (type.name() == "Boolean") listOf(EQ, NEQ)
                 // todo list types
                 // todo proper enum + object types and reference types

--- a/src/main/kotlin/org/neo4j/graphql/Translator.kt
+++ b/src/main/kotlin/org/neo4j/graphql/Translator.kt
@@ -271,7 +271,11 @@ class Translator(val schema: GraphQLSchema) {
                 ?: throw IllegalStateException("Field $field needs an @relation directive")
 
         var relInfo = relDetails(fieldObjectType, relDirective)
-        val inverse = isRelFromType && fieldObjectType.getFieldDefinition(relInfo.startField).type.inner().name != parent.name
+        val fieldRelationDirection = fieldDefinition.getDirective("relation")?.getArgument("direction")?.value?:"OUT"
+        val relationDirection = relDirective.getArgument("direction")?.value?.let {(it as EnumValue).name}?:"OUT"
+        val inverse = isRelFromType && ((fieldObjectType.getFieldDefinition(relInfo.startField).type.inner().name != parent.name) ||
+                (fieldObjectType.getFieldDefinition(relInfo.startField).type == fieldObjectType.getFieldDefinition(relInfo.endField).type &&
+                        fieldRelationDirection != relationDirection))
         if (inverse) relInfo = relInfo.copy(out = relInfo.out?.let { !it }, startField = relInfo.endField, endField = relInfo.startField)
 
         val (inArrow, outArrow) = relInfo.arrows

--- a/src/test/kotlin/org/neo4j/graphql/AugmentationTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/AugmentationTest.kt
@@ -46,15 +46,15 @@ class AugmentationTest {
         assertEquals("",augmentedSchema(ctx, typeFor("Person0")).query)
 
         augmentedSchema(ctx, typeFor("Person1")).let {
-            assertEquals("person1(name:String , _id: Int, filter:_Person1Filter, orderBy:_Person1Ordering, first:Int, offset:Int) : [Person1] ",it.query)
+            assertEquals("person1(name:String, _id: Int, filter:_Person1Filter, orderBy:_Person1Ordering, first:Int, offset:Int) : [Person1] ",it.query)
             assertEquals("",it.update)
             assertEquals("",it.delete)
             assertEquals("",it.create)
         }
 
-        assertEquals("person2(name:String, age:[Int] , _id: Int, filter:_Person2Filter, orderBy:_Person2Ordering, first:Int, offset:Int) : [Person2] ", augmentedSchema(ctx, typeFor("Person2")).query)
-        assertEquals("person3(name:String , _id: Int, filter:_Person3Filter, orderBy:_Person3Ordering, first:Int, offset:Int) : [Person3] ", augmentedSchema(ctx, typeFor("Person3")).query)
-        assertEquals("person4(id:ID, name:String , _id: Int, filter:_Person4Filter, orderBy:_Person4Ordering, first:Int, offset:Int) : [Person4] ", augmentedSchema(ctx, typeFor("Person4")).query)
+        assertEquals("person2(name:String, age:[Int], _id: Int, filter:_Person2Filter, orderBy:_Person2Ordering, first:Int, offset:Int) : [Person2] ", augmentedSchema(ctx, typeFor("Person2")).query)
+        assertEquals("person3(name:String, _id: Int, filter:_Person3Filter, orderBy:_Person3Ordering, first:Int, offset:Int) : [Person3] ", augmentedSchema(ctx, typeFor("Person3")).query)
+        assertEquals("person4(id:ID, name:String, _id: Int, filter:_Person4Filter, orderBy:_Person4Ordering, first:Int, offset:Int) : [Person4] ", augmentedSchema(ctx, typeFor("Person4")).query)
     }
 
     @Test

--- a/src/test/kotlin/org/neo4j/graphql/CypherDirectiveTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/CypherDirectiveTest.kt
@@ -96,6 +96,6 @@ schema {
     private fun assertQuery(query: String, expected: String, params : Map<String,Any?> = emptyMap()) {
         val result = Translator(SchemaBuilder.buildSchema(schema)).translate(query).first()
         assertEquals(expected, result.query)
-        assertTrue("${params} IN ${result.params}", params.all { val v=result.params[it.key]; when (v) { is Node -> v.isEqualTo(it.value as Node) else -> v == it.value}})
+        assertTrue("${params} IN ${result.params}", params.all { val v=result.params[it.key]; when (v) { is Node<*> -> v.isEqualTo(it.value as Node<*>) else -> v == it.value}})
     }
 }

--- a/src/test/kotlin/org/neo4j/graphql/TranslatorTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/TranslatorTest.kt
@@ -176,7 +176,32 @@ class TranslatorTest {
             } }"""
         assertQuery(query, "MATCH (user:User) WHERE user.name = \$userName RETURN user { .name," +
                 "referredBy:[(user)-[userReferredBy:REFERRED_BY]->(userReferredByReferredBy:User) | userReferredBy { .referralDate,referredBy:userReferredByReferredBy { .name } }][0]," +
-                "referred:[(user)<-[userReferred:REFERRED_BY]-(userReferredReferredBy:User) | userReferred { .referralDate,user:userReferredReferredBy { .name } }] } AS user",
+                "referred:[(user)<-[userReferred:REFERRED_BY]-(userReferredUser:User) | userReferred { .referralDate,user:userReferredUser { .name } }] } AS user",
+                mapOf("userName" to "Jane"), schema)
+    }
+
+    @Test
+    fun relationWithSameTypes_changedDirection() {
+        val schema = """
+            type User {
+              name:String
+              referredBy: Referral @relation(direction: OUT)
+              referred:[Referral] @relation(direction: IN)
+            }
+            type Referral @relation (name:"REFERRED_BY", from:"referredBy", to: "user", direction: IN ) {
+              user:User
+              referredBy:User
+              referralDate:String
+            }
+            """
+        val query = """ {user(name:"Jane") {
+            name
+            referredBy { referralDate referredBy {name} }
+            referred { referralDate user {name} }
+            } }"""
+        assertQuery(query, "MATCH (user:User) WHERE user.name = \$userName RETURN user { .name," +
+                "referredBy:[(user)-[userReferredBy:REFERRED_BY]->(userReferredByReferredBy:User) | userReferredBy { .referralDate,referredBy:userReferredByReferredBy { .name } }][0]," +
+                "referred:[(user)<-[userReferred:REFERRED_BY]-(userReferredUser:User) | userReferred { .referralDate,user:userReferredUser { .name } }] } AS user",
                 mapOf("userName" to "Jane"), schema)
     }
 

--- a/src/test/kotlin/org/neo4j/graphql/TranslatorTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/TranslatorTest.kt
@@ -156,6 +156,31 @@ class TranslatorTest {
     }
 
     @Test
+    fun relationWithSameTypes() {
+        val schema = """
+            type User {
+              name:String
+              referredBy: Referral @relation(direction: OUT)
+              referred:[Referral] @relation(direction: IN)
+            }
+            type Referral @relation (name:"REFERRED_BY", from:"user", to: "referredBy" ) {
+              user:User
+              referredBy:User
+              referralDate:String
+            }
+            """
+        val query = """ {user(name:"Jane") {
+            name
+            referredBy { referralDate referredBy {name} }
+            referred { referralDate user {name} }
+            } }"""
+        assertQuery(query, "MATCH (user:User) WHERE user.name = \$userName RETURN user { .name," +
+                "referredBy:[(user)-[userReferredBy:REFERRED_BY]->(userReferredByReferredBy:User) | userReferredBy { .referralDate,referredBy:userReferredByReferredBy { .name } }][0]," +
+                "referred:[(user)<-[userReferred:REFERRED_BY]-(userReferredReferredBy:User) | userReferred { .referralDate,user:userReferredReferredBy { .name } }] } AS user",
+                mapOf("userName" to "Jane"), schema)
+    }
+
+    @Test
     fun renderValues() {
         val query = "query(\$_param:String) { p:values(_param:\$_param) { age } }"
         //in new graphql args seem to be ordered alphabetically on schema creation
@@ -199,7 +224,7 @@ class TranslatorTest {
         assertQuery(query, "MATCH (person:Person) RETURN person { .name,.age } AS person")
     }
 
-    private fun assertQuery(query: String, expected: String, params : Map<String,Any> = emptyMap()) {
+    private fun assertQuery(query: String, expected: String, params: Map<String, Any> = emptyMap(), schema: String = this.schema) {
         val result = Translator(SchemaBuilder.buildSchema(schema)).translate(query).first()
         assertEquals(expected, result.query)
         assertTrue("${params} IN ${result.params}",result.params.entries.containsAll(params.entries))

--- a/src/test/resources/movies-test-schema.graphql
+++ b/src/test/resources/movies-test-schema.graphql
@@ -7,13 +7,13 @@ type Movie {
   plot: String
   poster: String
   imdbRating: Float
-  genres: [Genre] @relation(name: "IN_GENRE", direction: "OUT")
+  genres: [Genre] @relation(name: "IN_GENRE", direction: OUT)
   similar(first: Int = 3, offset: Int = 0): [Movie] @cypher(statement: "MATCH (this)--(:Genre)--(o:Movie) RETURN o")
   mostSimilar: Movie @cypher(statement: "RETURN this")
   degree: Int @cypher(statement: "RETURN SIZE((this)--())")
-  actors(first: Int = 3, offset: Int = 0, name: String): [Actor] @relation(name: "ACTED_IN", direction:"IN")
+  actors(first: Int = 3, offset: Int = 0, name: String): [Actor] @relation(name: "ACTED_IN", direction:IN)
   avgStars: Float
-  filmedIn: State @relation(name: "FILMED_IN", direction:"OUT")
+  filmedIn: State @relation(name: "FILMED_IN", direction: OUT)
   scaleRating(scale: Int = 3): Float @cypher(statement: "RETURN $scale * this.imdbRating")
   scaleRatingFloat(scale: Float = 1.5): Float @cypher(statement: "RETURN $scale * this.imdbRating")
   actorMovies: [Movie] @cypher(statement: "MATCH (this)-[:ACTED_IN*2]-(other:Movie) RETURN other")
@@ -22,7 +22,7 @@ type Movie {
 type Genre {
   _id: String!
   name: String
-  movies(first: Int = 3, offset: Int = 0): [Movie] @relation(name: "IN_GENRE", direction: "IN")
+  movies(first: Int = 3, offset: Int = 0): [Movie] @relation(name: "IN_GENRE", direction: IN)
   highestRatedMovie: Movie @cypher(statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1")
 }
 type State {
@@ -36,7 +36,7 @@ type Actor # implements Person
 {
   userId: ID!
   name: String
-  movies: [Movie] @relation(name: "ACTED_IN", direction:"OUT")
+  movies: [Movie] @relation(name: "ACTED_IN", direction:OUT)
 }
 type User # implements Person
 {


### PR DESCRIPTION
- upgrade to latest graphql version -> added generics on Type
- improve implementation of schema augmentation - lists are now immutable so have to be recreated and reset
- directives are added to schema as schema validation is now much stricter
- preventing _id duplicates in query params
- declare relation direction as enum
- fixes on tests