### PR TITLE
fixes #26: Support Mutations for Relationships

### DIFF
--- a/src/main/kotlin/org/neo4j/graphql/ExtensionFunctions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/ExtensionFunctions.kt
@@ -1,5 +1,8 @@
 package org.neo4j.graphql
 
+import graphql.Scalars
+import graphql.language.FieldDefinition
+import graphql.schema.GraphQLFieldDefinition
 import java.io.PrintWriter
 import java.io.StringWriter
 

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -1,5 +1,6 @@
 package org.neo4j.graphql
 
+import graphql.Scalars
 import graphql.language.*
 import graphql.schema.*
 
@@ -85,3 +86,14 @@ fun paramName(variable: String, argName: String, value: Any?) = when (value) {
     is VariableReference ->  value.name
     else -> "$variable${argName.capitalize()}"
 }
+
+fun FieldDefinition.isID(): Boolean = this.type.name() == "ID"
+fun FieldDefinition.isList(): Boolean = this.type is ListType
+fun GraphQLFieldDefinition.isID(): Boolean = this.type.inner() == Scalars.GraphQLID
+fun ObjectTypeDefinition.getFieldByType(typeName: String): FieldDefinition? = this.fieldDefinitions
+        .filter { it.type.inner().name() == typeName }
+        .firstOrNull()
+
+fun GraphQLDirective.getRelationshipType(): String = this.getArgument("name").value.toString()
+fun GraphQLDirective.getRelationshipDirection(): String = this.getArgument("direction")?.value?.toString() ?: "OUT"
+

--- a/src/test/kotlin/org/neo4j/graphql/AugmentationTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/AugmentationTest.kt
@@ -4,8 +4,10 @@ import graphql.language.ObjectTypeDefinition
 import graphql.schema.idl.SchemaParser
 import org.junit.Test
 import org.neo4j.graphql.Translator
-import org.neo4j.graphql.augmentedSchema
+import org.neo4j.graphql.createNodeMutation
+import org.neo4j.graphql.createRelationshipMutation
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class AugmentationTest {
     val types = SchemaParser().parse("""
@@ -15,16 +17,17 @@ class AugmentationTest {
         type Person3 { name: String!}
         type Person4 { id:ID!, name: String}
         type Person5 { id:ID!, movies:[Movie]}
-        type Movie { id:ID! }
+        type Movie { id:ID!, publishedBy: Publisher }
+        type Publisher { name:ID! }
     """)
 
     @Test
     fun testCrud() {
         val ctx = Translator.Context(query = Translator.CRUDConfig(enabled = false), mutation = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0")))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).create)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).create)
 
         // TODO a.s why merge and update are empty?
-        augmentedSchema(ctx, typeFor("Person1")).let {
+        createNodeMutation(ctx, typeFor("Person1")).let {
             assertEquals("createPerson1(name:String) : Person1 ",it.create)
             assertEquals("",it.merge)
             assertEquals("",it.update)
@@ -32,9 +35,9 @@ class AugmentationTest {
             assertEquals("",it.query)
         }
 
-        assertEquals("createPerson2(name:String, age:[Int]) : Person2 ", augmentedSchema(ctx, typeFor("Person2")).create)
-        assertEquals("createPerson3(name:String!) : Person3 ", augmentedSchema(ctx, typeFor("Person3")).create)
-        augmentedSchema(ctx, typeFor("Person4")).let {
+        assertEquals("createPerson2(name:String, age:[Int]) : Person2 ", createNodeMutation(ctx, typeFor("Person2")).create)
+        assertEquals("createPerson3(name:String!) : Person3 ", createNodeMutation(ctx, typeFor("Person3")).create)
+        createNodeMutation(ctx, typeFor("Person4")).let {
             assertEquals("createPerson4(id:ID!, name:String) : Person4 ",it.create)
             assertEquals("mergePerson4(id:ID!, name:String) : Person4 ",it.merge)
             assertEquals("updatePerson4(id:ID!, name:String) : Person4 ",it.update)
@@ -46,9 +49,9 @@ class AugmentationTest {
     @Test
     fun testQuery() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = false), query = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0")))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).query)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).query)
 
-        augmentedSchema(ctx, typeFor("Person1")).let {
+        createNodeMutation(ctx, typeFor("Person1")).let {
             assertEquals("person1(name:String, _id: Int, filter:_Person1Filter, orderBy:_Person1Ordering, first:Int, offset:Int) : [Person1] ",it.query)
             assertEquals("",it.merge)
             assertEquals("",it.update)
@@ -56,17 +59,17 @@ class AugmentationTest {
             assertEquals("",it.create)
         }
 
-        assertEquals("person2(name:String, age:[Int], _id: Int, filter:_Person2Filter, orderBy:_Person2Ordering, first:Int, offset:Int) : [Person2] ", augmentedSchema(ctx, typeFor("Person2")).query)
-        assertEquals("person3(name:String, _id: Int, filter:_Person3Filter, orderBy:_Person3Ordering, first:Int, offset:Int) : [Person3] ", augmentedSchema(ctx, typeFor("Person3")).query)
-        assertEquals("person4(id:ID, name:String, _id: Int, filter:_Person4Filter, orderBy:_Person4Ordering, first:Int, offset:Int) : [Person4] ", augmentedSchema(ctx, typeFor("Person4")).query)
+        assertEquals("person2(name:String, age:[Int], _id: Int, filter:_Person2Filter, orderBy:_Person2Ordering, first:Int, offset:Int) : [Person2] ", createNodeMutation(ctx, typeFor("Person2")).query)
+        assertEquals("person3(name:String, _id: Int, filter:_Person3Filter, orderBy:_Person3Ordering, first:Int, offset:Int) : [Person3] ", createNodeMutation(ctx, typeFor("Person3")).query)
+        assertEquals("person4(id:ID, name:String, _id: Int, filter:_Person4Filter, orderBy:_Person4Ordering, first:Int, offset:Int) : [Person4] ", createNodeMutation(ctx, typeFor("Person4")).query)
     }
 
     @Test
     fun testFilter() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = false), query = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0")))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).filterType)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).filterType)
 
-        augmentedSchema(ctx, typeFor("Person1")).let {
+        createNodeMutation(ctx, typeFor("Person1")).let {
             assertEquals("input _Person1Filter { AND:[_Person1Filter!], OR:[_Person1Filter!], NOT:[_Person1Filter!], name:String, name_not:String, name_in:String, " +
                     "name_not_in:String, name_lt:String, name_lte:String, name_gt:String, name_gte:String, name_contains:String, name_not_contains:String, " +
                     "name_starts_with:String, name_not_starts_with:String, name_ends_with:String, name_not_ends_with:String } ",it.filterType)
@@ -80,24 +83,24 @@ class AugmentationTest {
                 "name_not:String, name_in:String, name_not_in:String, name_lt:String, name_lte:String, name_gt:String, name_gte:String, " +
                 "name_contains:String, name_not_contains:String, name_starts_with:String, name_not_starts_with:String, name_ends_with:String, " +
                 "name_not_ends_with:String, age:[Int], age_not:[Int], age_in:[Int], age_not_in:[Int], age_lt:[Int], age_lte:[Int], " +
-                "age_gt:[Int], age_gte:[Int] } ", augmentedSchema(ctx, typeFor("Person2")).filterType)
+                "age_gt:[Int], age_gte:[Int] } ", createNodeMutation(ctx, typeFor("Person2")).filterType)
         assertEquals("input _Person3Filter { AND:[_Person3Filter!], OR:[_Person3Filter!], NOT:[_Person3Filter!], name:String, " +
                 "name_not:String, name_in:String, name_not_in:String, name_lt:String, name_lte:String, name_gt:String, name_gte:String, " +
                 "name_contains:String, name_not_contains:String, name_starts_with:String, name_not_starts_with:String, name_ends_with:String, " +
-                "name_not_ends_with:String } ", augmentedSchema(ctx, typeFor("Person3")).filterType)
+                "name_not_ends_with:String } ", createNodeMutation(ctx, typeFor("Person3")).filterType)
         assertEquals("input _Person4Filter { AND:[_Person4Filter!], OR:[_Person4Filter!], NOT:[_Person4Filter!], id:ID, id_not:ID, " +
                 "id_in:ID, id_not_in:ID, id_lt:ID, id_lte:ID, id_gt:ID, id_gte:ID, id_contains:ID, id_not_contains:ID, " +
                 "id_starts_with:ID, id_not_starts_with:ID, id_ends_with:ID, id_not_ends_with:ID, name:String, name_not:String, " +
                 "name_in:String, name_not_in:String, name_lt:String, name_lte:String, name_gt:String, name_gte:String, name_contains:String, " +
                 "name_not_contains:String, name_starts_with:String, name_not_starts_with:String, name_ends_with:String, " +
-                "name_not_ends_with:String } ", augmentedSchema(ctx, typeFor("Person4")).filterType)
+                "name_not_ends_with:String } ", createNodeMutation(ctx, typeFor("Person4")).filterType)
     }
     @Test
     fun testInputTypes() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = false), query = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0")))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).inputType)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).inputType)
 
-        augmentedSchema(ctx, typeFor("Person1")).let {
+        createNodeMutation(ctx, typeFor("Person1")).let {
             assertEquals("input _Person1Input { name:String } ",it.inputType)
             assertEquals("",it.merge)
             assertEquals("",it.update)
@@ -105,17 +108,17 @@ class AugmentationTest {
             assertEquals("",it.create)
         }
 
-        assertEquals("input _Person2Input { name:String, age:[Int] } ", augmentedSchema(ctx, typeFor("Person2")).inputType)
-        assertEquals("input _Person3Input { name:String } ", augmentedSchema(ctx, typeFor("Person3")).inputType)
-        assertEquals("input _Person4Input { id:ID, name:String } ", augmentedSchema(ctx, typeFor("Person4")).inputType)
+        assertEquals("input _Person2Input { name:String, age:[Int] } ", createNodeMutation(ctx, typeFor("Person2")).inputType)
+        assertEquals("input _Person3Input { name:String } ", createNodeMutation(ctx, typeFor("Person3")).inputType)
+        assertEquals("input _Person4Input { id:ID, name:String } ", createNodeMutation(ctx, typeFor("Person4")).inputType)
     }
 
     @Test
     fun testOrderings() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = false), query = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0")))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).ordering)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).ordering)
 
-        augmentedSchema(ctx, typeFor("Person1")).let {
+        createNodeMutation(ctx, typeFor("Person1")).let {
             assertEquals("enum _Person1Ordering { name_asc ,name_desc } ",it.ordering)
             assertEquals("",it.merge)
             assertEquals("",it.update)
@@ -123,20 +126,20 @@ class AugmentationTest {
             assertEquals("",it.create)
         }
 
-        assertEquals("enum _Person2Ordering { name_asc ,name_desc,age_asc ,age_desc } ", augmentedSchema(ctx, typeFor("Person2")).ordering)
-        assertEquals("enum _Person3Ordering { name_asc ,name_desc } ", augmentedSchema(ctx, typeFor("Person3")).ordering)
-        assertEquals("enum _Person4Ordering { id_asc ,id_desc,name_asc ,name_desc } ", augmentedSchema(ctx, typeFor("Person4")).ordering)
+        assertEquals("enum _Person2Ordering { name_asc ,name_desc,age_asc ,age_desc } ", createNodeMutation(ctx, typeFor("Person2")).ordering)
+        assertEquals("enum _Person3Ordering { name_asc ,name_desc } ", createNodeMutation(ctx, typeFor("Person3")).ordering)
+        assertEquals("enum _Person4Ordering { id_asc ,id_desc,name_asc ,name_desc } ", createNodeMutation(ctx, typeFor("Person4")).ordering)
     }
 
     @Test
     fun testMutations() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0","Person1","Person2","Person3")), query = Translator.CRUDConfig(enabled = false))
-        assertEquals("",augmentedSchema(ctx, typeFor("Person0")).ordering)
-        assertEquals("",augmentedSchema(ctx, typeFor("Person1")).filterType)
-        assertEquals("",augmentedSchema(ctx, typeFor("Person2")).query)
-        assertEquals("",augmentedSchema(ctx, typeFor("Person3")).inputType)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person0")).ordering)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person1")).filterType)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person2")).query)
+        assertEquals("",createNodeMutation(ctx, typeFor("Person3")).inputType)
 
-        augmentedSchema(ctx, typeFor("Person4")).let {
+        createNodeMutation(ctx, typeFor("Person4")).let {
             assertEquals("",it.ordering)
             assertEquals("",it.filterType)
             assertEquals("createPerson4(id:ID!, name:String) : Person4 ",it.create)
@@ -149,13 +152,23 @@ class AugmentationTest {
     @Test
     fun testMutationForRelations() {
         val ctx = Translator.Context(mutation = Translator.CRUDConfig(enabled = true, exclude = listOf("Person0","Person1","Person2","Person3", "Person4")), query = Translator.CRUDConfig(enabled = false))
-        augmentedSchema(ctx, typeFor("Person5")).let {
+        createRelationshipMutation(ctx, typeFor("Person5"), typeFor("Movie")).let {
+            assertNotNull(it)
             assertEquals("",it.ordering)
             assertEquals("",it.filterType)
-            assertEquals("createPerson5(id:ID!) : Person5 ",it.create)
-            assertEquals("mergePerson5(id:ID!) : Person5 ",it.merge)
-            assertEquals("updatePerson5(id:ID!) : Person5 ",it.update)
-            assertEquals("deletePerson5(id:ID!) : Person5 ",it.delete)
+            assertEquals("addPerson5Movies(id:ID!, movies:[ID!]!) : Person5", it.create)
+            assertEquals("deletePerson5Movies(id:ID!, movies:[ID!]!) : Person5", it.delete)
+            assertEquals("",it.merge)
+            assertEquals("",it.update)
+        }
+        createRelationshipMutation(ctx, typeFor("Movie"), typeFor("Publisher")).let {
+            assertNotNull(it)
+            assertEquals("",it.ordering)
+            assertEquals("",it.filterType)
+            assertEquals("addMoviePublishedBy(id:ID!, publishedBy:ID!) : Movie", it.create)
+            assertEquals("deleteMoviePublishedBy(id:ID!, publishedBy:ID!) : Movie", it.delete)
+            assertEquals("",it.merge)
+            assertEquals("",it.update)
         }
     }
 

--- a/src/test/kotlin/org/neo4j/graphql/TckTest.kt
+++ b/src/test/kotlin/org/neo4j/graphql/TckTest.kt
@@ -72,6 +72,7 @@ class TckTest(val schema:String) {
             Assert.assertTrue("${params} IN ${result.params}", fixNumbers(result.params).entries.containsAll(fixNumbers(params).entries))
         }
 
-        private fun fixNumbers(params: Map<String, Any?>) = params.mapValues{ (_,v) -> when(v) { is Float -> v.toDouble(); is Int -> v.toLong(); else -> v } }
+        private fun fixNumber(v: Any?): Any? = when(v) { is Float -> v.toDouble(); is Int -> v.toLong(); else -> v }
+        private fun fixNumbers(params: Map<String, Any?>) = params.mapValues{ (_,v) -> when(v) { is List<*> -> v.map { fixNumber(it) }; else -> fixNumber(v) } }
     }
 }

--- a/src/test/resources/movie-test.md
+++ b/src/test/resources/movie-test.md
@@ -360,6 +360,122 @@ WITH actor
 RETURN actor { .name } AS actor
 ```
 
+### Should auto generate `add` relationship mutations for arrays
+
+```graphql
+mutation {
+  add: addMovieGenres(movieId: 1, genres: ["Action", "Fantasy"]) {
+    title
+  }
+}
+```
+
+```params
+{"movieId": 1, "genres": ["Action", "Fantasy"]}
+```
+
+```cypher
+MATCH (from:Movie {movieId:$movieId})
+MATCH (to:Genre)
+WHERE to.name IN $genres
+MERGE (from)-[r:IN_GENRE]->(to)
+WITH DISTINCT from
+RETURN from { .title } AS movie
+```
+
+### Should auto generate `delete` relationship mutations for arrays
+
+```graphql
+mutation {
+  del: deleteMovieGenres(movieId: 1, genres: ["Action", "Fantasy"]) {
+    title
+  }
+}
+```
+
+```params
+{"movieId": 1, "genres": ["Action", "Fantasy"]}
+```
+
+```cypher
+MATCH (from:Movie {movieId:$movieId})
+MATCH (to:Genre)
+WHERE to.name IN $genres
+MATCH (from)-[r:IN_GENRE]->(to)
+DELETE r
+WITH DISTINCT from
+RETURN from { .title } AS movie
+```
+
+### Should auto generate `add` relationship mutations
+
+```graphql
+mutation {
+  add: addMoviePublishedBy(movieId: 1, publishedBy: "Company") {
+    title
+  }
+}
+```
+
+```params
+{"movieId": 1, "publishedBy": "Company"}
+```
+
+```cypher
+MATCH (from:Movie {movieId:$movieId})
+MATCH (to:Publisher)
+WHERE to.name = $publishedBy
+MERGE (from)-[r:PUBLISHED_BY]->(to)
+WITH DISTINCT from
+RETURN from { .title } AS movie
+```
+
+### Should auto generate `delete` relationship mutations
+
+```graphql
+mutation {
+  del: deleteMoviePublishedBy(movieId: 1, publishedBy: "Company") {
+    title
+  }
+}
+```
+
+```params
+{"movieId": 1, "publishedBy": "Company"}
+```
+
+```cypher
+MATCH (from:Movie {movieId:$movieId})
+MATCH (to:Publisher)
+WHERE to.name = $publishedBy
+MATCH (from)-[r:PUBLISHED_BY]->(to)
+DELETE r
+WITH DISTINCT from
+RETURN from { .title } AS movie
+```
+
+### Should auto generate `add` recursive relationship mutations for arrays
+
+```graphql
+mutation {
+  add: addUserKnows(userId: 1, knows: [10, 23]) {
+    name
+  }
+}
+```
+
+```params
+{"userId": 1, "knows": [10, 23]}
+```
+
+```cypher
+MATCH (from:User {userId:$userId})
+MATCH (to:User)
+WHERE to.userId IN $knows
+MERGE (from)-[r:KNOWS]->(to)
+WITH DISTINCT from
+RETURN from { .name } AS user
+```
 ## Order By
 
 ### Descending, top level

--- a/src/test/resources/movies-test-schema.graphql
+++ b/src/test/resources/movies-test-schema.graphql
@@ -20,11 +20,15 @@ type Movie {
   MATCH (this)-[:ACTED_IN*2]-(other:Movie)
   RETURN other
   """)
+  publishedBy: Publisher @relation(name: "PUBLISHED_BY", direction: OUT)
   ratings: [Rated]
+}
+type Publisher {
+  name: ID!
 }
 type Genre {
   _id: String!
-  name: String
+  name: ID!
   movies(first: Int = 3, offset: Int = 0): [Movie] @relation(name: "IN_GENRE", direction: IN)
   highestRatedMovie: Movie @cypher(statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1")
 }
@@ -47,6 +51,7 @@ type User # implements Person
   name: String
   rated(rating: Int): [Rated]
   friends(since: Int): [FriendOf]
+  knows: [User] @relation(name: "KNOWS", direction:OUT)
 }
 type FriendOf {
   from: User


### PR DESCRIPTION
Added auto-generated mutation support for relationships.
Given the following schema:

```
type Movie { id:ID!, publishedBy: Publisher }
type Publisher { name:ID! }
```
we create these two mutations:

```
addMoviePublishedBy(id:ID!, publishedBy:ID!) : Movie
deleteMoviePublishedBy(id:ID!, publishedBy:ID!) : Movie
```