### PR TITLE
Add support for spatial point values and distance comparisons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,8 @@
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
-            <artifactId>neo4j-opencypher-dsl</artifactId>
-            <version>1.1.0</version>
+            <artifactId>neo4j-cypher-dsl</artifactId>
+            <version>2020.0.1</version>
         </dependency>
     </dependencies>
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -246,6 +246,7 @@ This example doesn't handle introspection queries, but the one in the test direc
 * date(time)
 * interfaces
 * complex filter parameters, with optional query optimization strategy
+* spatial
 
 === Next
 
@@ -254,7 +255,6 @@ This example doesn't handle introspection queries, but the one in the test direc
 * input types
 * unions
 * scalars
-* spatial
 
 == Documentation
 

--- a/src/main/kotlin/org/neo4j/cypherdsl/core/PassThrough.kt
+++ b/src/main/kotlin/org/neo4j/cypherdsl/core/PassThrough.kt
@@ -1,4 +1,4 @@
-package org.neo4j.opencypherdsl
+package org.neo4j.cypherdsl.core
 
 import java.util.*
 

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -3,6 +3,8 @@ package org.neo4j.graphql
 import graphql.Scalars
 import graphql.language.*
 import graphql.schema.*
+import org.neo4j.cypherdsl.core.Node
+import org.neo4j.cypherdsl.core.Relationship
 import org.neo4j.graphql.DirectiveConstants.Companion.CYPHER
 import org.neo4j.graphql.DirectiveConstants.Companion.CYPHER_STATEMENT
 import org.neo4j.graphql.DirectiveConstants.Companion.DYNAMIC
@@ -17,8 +19,6 @@ import org.neo4j.graphql.DirectiveConstants.Companion.RELATION_FROM
 import org.neo4j.graphql.DirectiveConstants.Companion.RELATION_NAME
 import org.neo4j.graphql.DirectiveConstants.Companion.RELATION_TO
 import org.neo4j.graphql.handler.projection.ProjectionBase
-import org.neo4j.opencypherdsl.Node
-import org.neo4j.opencypherdsl.Relationship
 
 fun Type<Type<*>>.name(): String? = if (this.inner() is TypeName) (this.inner() as TypeName).name else null
 fun Type<Type<*>>.inner(): Type<Type<*>> = when (this) {

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -35,7 +35,8 @@ fun GraphQLType.inner(): GraphQLType = when (this) {
 
 fun GraphQLType.isList() = this is GraphQLList || (this is GraphQLNonNull && this.wrappedType is GraphQLList)
 fun GraphQLType.isScalar() = this.inner().let { it is GraphQLScalarType || it.name.startsWith("_Neo4j") }
-fun GraphQLType.isNeo4jType() = this.inner().name?.startsWith("_Neo4j") == true
+fun GraphQLType.isNeo4jType() = this.innerName().startsWith("_Neo4j")
+fun GraphQLType.isNeo4jSpatialType() = this.innerName().startsWith("_Neo4jPoint")
 fun GraphQLFieldDefinition.isNeo4jType(): Boolean = this.type.isNeo4jType()
 
 fun GraphQLFieldDefinition.isRelationship() = !type.isNeo4jType() && this.type.inner().let { it is GraphQLFieldsContainer }

--- a/src/main/kotlin/org/neo4j/graphql/Neo4jTypes.kt
+++ b/src/main/kotlin/org/neo4j/graphql/Neo4jTypes.kt
@@ -4,14 +4,13 @@ import graphql.language.Field
 import graphql.language.ObjectValue
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
-import java.time.*
-import java.time.temporal.Temporal
 
 const val NEO4j_FORMATTED_PROPERTY_KEY = "formatted"
+const val NEO4j_POINT_DISTANCE_FILTER = "_Neo4jPointDistanceFilter"
+const val NEO4j_POINT_DISTANCE_FILTER_SUFFIX = "_distance"
 
 data class TypeDefinition(
         val name: String,
-        val type: Class<out Temporal>,
         val typeDefinition: String,
         val inputDefinition: String = typeDefinition + "Input"
 )
@@ -75,9 +74,10 @@ data class Neo4jQueryConversion(val name: String, val propertyName: String, val 
 }
 
 val neo4jTypeDefinitions = listOf(
-        TypeDefinition("LocalTime", OffsetTime::class.java, "_Neo4jTime"),
-        TypeDefinition("Date", LocalDate::class.java, "_Neo4jDate"),
-        TypeDefinition("DateTime", LocalDateTime::class.java, "_Neo4jDateTime"),
-        TypeDefinition("Time", Instant::class.java, "_Neo4jLocalTime"),
-        TypeDefinition("LocalDateTime", OffsetDateTime::class.java, "_Neo4jLocalDateTime")
+        TypeDefinition("LocalTime", "_Neo4jTime"),
+        TypeDefinition("Date", "_Neo4jDate"),
+        TypeDefinition("DateTime", "_Neo4jDateTime"),
+        TypeDefinition("Time", "_Neo4jLocalTime"),
+        TypeDefinition("LocalDateTime", "_Neo4jLocalDateTime"),
+        TypeDefinition("Point", "_Neo4jPoint")
 )

--- a/src/main/kotlin/org/neo4j/graphql/Predicates.kt
+++ b/src/main/kotlin/org/neo4j/graphql/Predicates.kt
@@ -4,12 +4,16 @@ import graphql.Scalars
 import graphql.language.NullValue
 import graphql.language.Value
 import graphql.schema.*
+import org.neo4j.cypherdsl.core.Condition
+import org.neo4j.cypherdsl.core.Expression
+import org.neo4j.cypherdsl.core.Functions
+import org.neo4j.cypherdsl.core.Functions.point
+import org.neo4j.cypherdsl.core.Parameter
 import org.neo4j.graphql.Predicate.Companion.resolvePredicate
 import org.neo4j.graphql.handler.projection.ProjectionBase
-import org.neo4j.opencypherdsl.*
 import org.slf4j.LoggerFactory
 
-typealias CypherDSL = org.neo4j.opencypherdsl.Cypher
+typealias CypherDSL = org.neo4j.cypherdsl.core.Cypher
 
 interface Predicate {
     fun toExpression(variable: String): Cypher

--- a/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
+++ b/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
@@ -3,10 +3,10 @@ package org.neo4j.graphql.handler
 import graphql.Scalars
 import graphql.language.Field
 import graphql.schema.*
+import org.neo4j.cypherdsl.core.PassThrough
+import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.graphql.*
 import org.neo4j.graphql.handler.filter.OptimizedFilterHandler
-import org.neo4j.opencypherdsl.PassThrough
-import org.neo4j.opencypherdsl.renderer.Renderer
 
 class QueryHandler private constructor(
         type: GraphQLFieldsContainer,

--- a/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
+++ b/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
@@ -4,12 +4,12 @@ import graphql.language.*
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLObjectType
+import org.neo4j.cypherdsl.core.*
+import org.neo4j.cypherdsl.core.Cypher
+import org.neo4j.cypherdsl.core.Node
+import org.neo4j.cypherdsl.core.StatementBuilder.*
 import org.neo4j.graphql.*
 import org.neo4j.graphql.handler.projection.ProjectionBase
-import org.neo4j.opencypherdsl.*
-import org.neo4j.opencypherdsl.Cypher
-import org.neo4j.opencypherdsl.Node
-import org.neo4j.opencypherdsl.StatementBuilder.*
 
 
 typealias WhereClauseFactory = (

--- a/src/main/kotlin/org/neo4j/opencypherdsl/DslExtensions.kt
+++ b/src/main/kotlin/org/neo4j/opencypherdsl/DslExtensions.kt
@@ -1,0 +1,4 @@
+package org.neo4j.opencypherdsl
+
+// TODO remove after https://github.com/neo4j-contrib/cypher-dsl/issues/63 is merged
+fun point(parameter: Parameter) = FunctionInvocation("point", parameter)

--- a/src/main/kotlin/org/neo4j/opencypherdsl/DslExtensions.kt
+++ b/src/main/kotlin/org/neo4j/opencypherdsl/DslExtensions.kt
@@ -1,4 +1,0 @@
-package org.neo4j.opencypherdsl
-
-// TODO remove after https://github.com/neo4j-contrib/cypher-dsl/issues/63 is merged
-fun point(parameter: Parameter) = FunctionInvocation("point", parameter)

--- a/src/main/resources/neo4j.graphql
+++ b/src/main/resources/neo4j.graphql
@@ -63,3 +63,46 @@ type _Neo4jLocalDateTime {
   nanosecond: Int
   formatted: String
 }
+
+type _Neo4jPoint{
+  # The first element of the Coordinate
+  x: Float
+
+  # The second element of the Coordinate
+  y: Float
+
+  # The third element of the Coordinate
+  z: Float
+
+  # The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+  # Range -180.0 to 180.0
+  longitude: Float
+
+  # The second element of the Coordinate for geographic CRS, degrees North of the equator
+  # Range -90.0 to 90.0
+  latitude: Float
+
+  # The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)
+  height: Float
+
+  # The coordinate reference systems (CRS)
+  # -------------------------------------
+  # posible values:
+  # * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+  #   * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+  #   * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+  # * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+  #   * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+  #   * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+  # * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+  # * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  crs: String
+
+  # The internal Neo4j ID for the CRS
+  # One of:
+  # * `4326`: represents CRS `wgs-84`
+  # * `4979`: represents CRS `wgs-84-3d`
+  # * `7203`: represents CRS `cartesian`
+  # * `9157`: represents CRS `cartesian-3d`
+  srid: Int
+}

--- a/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
+++ b/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
@@ -74,7 +74,8 @@ open class AsciiDocTestSuite {
         private fun fixNumber(v: Any?): Any? = when (v) {
             is Float -> v.toDouble()
             is Int -> v.toLong()
-            is List<*> -> v.map { fixNumber(it) }
+            is Iterable<*> -> v.map { fixNumber(it) }
+            is Sequence<*> -> v.map { fixNumber(it) }
             is Map<*, *> -> v.mapValues { fixNumber(it.value) }
             else -> v
         }

--- a/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
+++ b/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
@@ -72,16 +72,14 @@ open class AsciiDocTestSuite {
         }
 
         private fun fixNumber(v: Any?): Any? = when (v) {
-            is Float -> v.toDouble(); is Int -> v.toLong(); else -> v
+            is Float -> v.toDouble()
+            is Int -> v.toLong()
+            is List<*> -> v.map { fixNumber(it) }
+            is Map<*, *> -> v.mapValues { fixNumber(it.value) }
+            else -> v
         }
 
-        fun fixNumbers(params: Map<String, Any?>) = params.mapValues { (_, v) ->
-            when (v) {
-                is List<*> -> v.map { fixNumber(it) }
-                is Map<*, *> -> v.mapValues { fixNumber(it.value) }
-                else -> fixNumber(v)
-            }
-        }
+        fun fixNumbers(params: Map<String, Any?>) = params.mapValues { (_, v) -> fixNumber(v) }
 
         fun String.parseJsonMap(): Map<String, Any?> = this.let {
             @Suppress("UNCHECKED_CAST")

--- a/src/test/resources/augmentation-tests.adoc
+++ b/src/test/resources/augmentation-tests.adoc
@@ -7,7 +7,7 @@
 [source,graphql,schema=true]
 ----
 interface HasMovies { movies:[Movie] }
-type Person0 { name: String, born: _Neo4jTime }
+type Person0 { name: String, born: _Neo4jTime, location: _Neo4jPoint }
 type Person1 { name: String, born: _Neo4jDate }
 type Person2 { name: String, age: [Int], born: _Neo4jDateTime }
 type Person3 { name: String!, born: _Neo4jLocalTime }
@@ -31,6 +31,14 @@ type Knows4 @relation(name:"KNOWS", from: "source", to: "knows"){
   source: Person4!
   knows: Person4!
   json: DynamicProperties @dynamic(prefix: "prefix.")
+}
+
+type Query {
+  PersonByLocation(location: _Neo4jPointInput): [Person0!]!
+}
+
+schema {
+  query: Query
 }
 ----
 
@@ -92,18 +100,21 @@ type Movie {
 }
 
 type Mutation {
+  #Deletes Knows0 and returns the type itself
   deleteKnows0(id: ID!): Knows0
   mergeKnows0(id: ID!, json: DynamicProperties): Knows0!
   updateKnows0(id: ID!, json: DynamicProperties): Knows0
-
+  #Deletes Knows1 and returns the type itself
   deleteKnows1(id: ID!): Knows1
 
   createKnows4(json: DynamicProperties, knows_id: ID!, source_id: ID!): Knows4!
+  #Deletes Knows4 and returns the type itself
   deleteKnows4(_id: ID!): Knows4
   mergeKnows4(_id: ID!, json: DynamicProperties): Knows4!
   updateKnows4(_id: ID!, json: DynamicProperties): Knows4
 
   createMovie(id: ID!): Movie!
+  #Deletes Movie and returns the type itself
   deleteMovie(id: ID!): Movie
 
   addMoviePublishedBy(id: ID!, publishedBy: ID!): Movie!
@@ -116,23 +127,26 @@ type Mutation {
   createPerson3(born: _Neo4jLocalTimeInput, name: String!): Person3!
 
   createPerson4(born: _Neo4jLocalDateTimeInput, id: ID!, name: String): Person4!
-
+  #Deletes Person4 and returns the type itself
   deletePerson4(id: ID!): Person4
   mergePerson4(born: _Neo4jLocalDateTimeInput, id: ID!, name: String): Person4!
   updatePerson4(born: _Neo4jLocalDateTimeInput, id: ID!, name: String): Person4
 
   createPerson5(id: ID!): Person5!
+  #Deletes Person5 and returns the type itself
   deletePerson5(id: ID!): Person5
 
   addPerson5Movies(id: ID!, movies: [ID!]!): Person5!
   deletePerson5Movies(id: ID!, movies: [ID!]!): Person5
 
   createPublisher(name: ID!): Publisher!
+  #Deletes Publisher and returns the type itself
   deletePublisher(name: ID!): Publisher
 }
 
 type Person0 {
   born: _Neo4jTime
+  location: _Neo4jPoint
   name: String
 }
 
@@ -168,6 +182,7 @@ type Publisher {
 }
 
 type Query {
+  PersonByLocation(first: Int, location: _Neo4jPointInput, offset: Int): [Person0!]!
 }
 
 type _Neo4jDate {
@@ -214,6 +229,42 @@ type _Neo4jLocalTime {
   second: Int
 }
 
+type _Neo4jPoint {
+  # The coordinate reference systems (CRS)
+  # -------------------------------------
+  # posible values:
+  # * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+  #   * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+  #   * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+  # * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+  #   * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+  #   * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+  # * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+  # * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  crs: String
+  # The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)
+  height: Float
+  # The second element of the Coordinate for geographic CRS, degrees North of the equator
+  # Range -90.0 to 90.0
+  latitude: Float
+  # The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+  # Range -180.0 to 180.0
+  longitude: Float
+  # The internal Neo4j ID for the CRS
+  # One of:
+  # * `4326`: represents CRS `wgs-84`
+  # * `4979`: represents CRS `wgs-84-3d`
+  # * `7203`: represents CRS `cartesian`
+  # * `9157`: represents CRS `cartesian-3d`
+  srid: Int
+  # The first element of the Coordinate
+  x: Float
+  # The second element of the Coordinate
+  y: Float
+  # The third element of the Coordinate
+  z: Float
+}
+
 type _Neo4jTime {
   formatted: String
   hour: Int
@@ -224,6 +275,14 @@ type _Neo4jTime {
   second: Int
   timezone: String
 }
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+scalar DynamicProperties
 
 input _Neo4jDateInput {
   day: Int
@@ -269,6 +328,17 @@ input _Neo4jLocalTimeInput {
   second: Int
 }
 
+input _Neo4jPointInput {
+  crs: String
+  height: Float
+  latitude: Float
+  longitude: Float
+  srid: Int
+  x: Float
+  y: Float
+  z: Float
+}
+
 input _Neo4jTimeInput {
   formatted: String
   hour: Int
@@ -280,17 +350,10 @@ input _Neo4jTimeInput {
   timezone: String
 }
 
-enum RelationDirection {
-  BOTH
-  IN
-  OUT
-}
-
 directive @relation(name:String, direction: RelationDirection = OUT, from: String = "from", to: String = "to") on FIELD_DEFINITION | OBJECT
 directive @cypher(statement:String) on FIELD_DEFINITION
 directive @property(name:String) on FIELD_DEFINITION
 directive @dynamic(prefix:String = "properties.") on FIELD_DEFINITION
-scalar DynamicProperties
 ----
 
 === Disable Mutations
@@ -349,6 +412,7 @@ type Movie {
 
 type Person0 {
   born: _Neo4jTime
+  location: _Neo4jPoint
   name: String
 }
 
@@ -393,6 +457,7 @@ type Query {
   person3(born: _Neo4jLocalTimeInput, filter: _Person3Filter, first: Int, name: String, offset: Int, orderBy: _Person3Ordering): [Person3!]!
   person4(born: _Neo4jLocalDateTimeInput, filter: _Person4Filter, first: Int, id: ID, name: String, offset: Int, orderBy: _Person4Ordering): [Person4!]!
   person5(filter: _Person5Filter, first: Int, id: ID, offset: Int, orderBy: _Person5Ordering): [Person5!]!
+  PersonByLocation(first: Int, location: _Neo4jPointInput, offset: Int): [Person0!]!
   publisher(filter: _PublisherFilter, first: Int, name: ID, offset: Int, orderBy: _PublisherOrdering): [Publisher!]!
 }
 
@@ -440,6 +505,42 @@ type _Neo4jLocalTime {
   second: Int
 }
 
+type _Neo4jPoint {
+  # The coordinate reference systems (CRS)
+  # -------------------------------------
+  # posible values:
+  # * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+  #   * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+  #   * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+  # * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+  #   * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+  #   * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+  # * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+  # * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  crs: String
+  # The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)
+  height: Float
+  # The second element of the Coordinate for geographic CRS, degrees North of the equator
+  # Range -90.0 to 90.0
+  latitude: Float
+  # The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+  # Range -180.0 to 180.0
+  longitude: Float
+  # The internal Neo4j ID for the CRS
+  # One of:
+  # * `4326`: represents CRS `wgs-84`
+  # * `4979`: represents CRS `wgs-84-3d`
+  # * `7203`: represents CRS `cartesian`
+  # * `9157`: represents CRS `cartesian-3d`
+  srid: Int
+  # The first element of the Coordinate
+  x: Float
+  # The second element of the Coordinate
+  y: Float
+  # The third element of the Coordinate
+  z: Float
+}
+
 type _Neo4jTime {
   formatted: String
   hour: Int
@@ -449,6 +550,12 @@ type _Neo4jTime {
   nanosecond: Int
   second: Int
   timezone: String
+}
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
 }
 
 enum _Knows0Ordering {
@@ -516,6 +623,8 @@ enum _PublisherOrdering {
   name_asc
   name_desc
 }
+
+scalar DynamicProperties
 
 input _Knows0Filter {
   AND: [_Knows0Filter!]
@@ -736,6 +845,22 @@ input _Neo4jLocalTimeInput {
   second: Int
 }
 
+input _Neo4jPointDistanceFilter {
+  distance: Float
+  point: _Neo4jPointInput
+}
+
+input _Neo4jPointInput {
+  crs: String
+  height: Float
+  latitude: Float
+  longitude: Float
+  srid: Int
+  x: Float
+  y: Float
+  z: Float
+}
+
 input _Neo4jTimeInput {
   formatted: String
   hour: Int
@@ -755,6 +880,13 @@ input _Person0Filter {
   born_in: [_Neo4jTimeInput]
   born_not: _Neo4jTimeInput
   born_not_in: [_Neo4jTimeInput]
+  location: _Neo4jPointInput
+  location_distance: _Neo4jPointDistanceFilter
+  location_distance_gt: _Neo4jPointDistanceFilter
+  location_distance_gte: _Neo4jPointDistanceFilter
+  location_distance_lt: _Neo4jPointDistanceFilter
+  location_distance_lte: _Neo4jPointDistanceFilter
+  location_not: _Neo4jPointInput
   name: String
   name_contains: String
   name_ends_with: String
@@ -971,17 +1103,10 @@ input _PublisherInput {
   name: ID
 }
 
-enum RelationDirection {
-  IN
-  OUT
-  BOTH
-}
-
 directive @relation(name:String, direction: RelationDirection = OUT, from: String = "from", to: String = "to") on FIELD_DEFINITION | OBJECT
 directive @cypher(statement:String) on FIELD_DEFINITION
 directive @property(name:String) on FIELD_DEFINITION
 directive @dynamic(prefix:String = "properties.") on FIELD_DEFINITION
-scalar DynamicProperties
 ----
 
 
@@ -1045,35 +1170,42 @@ type Movie {
 }
 
 type Mutation {
+  #Deletes Knows0 and returns the type itself
   deleteKnows0(id: ID!): Knows0
   mergeKnows0(id: ID!, json: DynamicProperties): Knows0!
   updateKnows0(id: ID!, json: DynamicProperties): Knows0
 
+  #Deletes Knows1 and returns the type itself
   deleteKnows1(id: ID!): Knows1
 
   createKnows4(json: DynamicProperties, knows_id: ID!, source_id: ID!): Knows4!
+  #Deletes Knows4 and returns the type itself
   deleteKnows4(_id: ID!): Knows4
   mergeKnows4(_id: ID!, json: DynamicProperties): Knows4!
   updateKnows4(_id: ID!, json: DynamicProperties): Knows4
 
   createMovie(id: ID!): Movie!
+  #Deletes Movie and returns the type itself
   deleteMovie(id: ID!): Movie
 
   addMoviePublishedBy(id: ID!, publishedBy: ID!): Movie!
   deleteMoviePublishedBy(id: ID!, publishedBy: ID!): Movie
 
   createPerson5(id: ID!): Person5!
+  #Deletes Person5 and returns the type itself
   deletePerson5(id: ID!): Person5
 
   addPerson5Movies(id: ID!, movies: [ID!]!): Person5!
   deletePerson5Movies(id: ID!, movies: [ID!]!): Person5
 
   createPublisher(name: ID!): Publisher!
+  #Deletes Publisher and returns the type itself
   deletePublisher(name: ID!): Publisher
 }
 
 type Person0 {
   born: _Neo4jTime
+  location: _Neo4jPoint
   name: String
 }
 
@@ -1109,6 +1241,7 @@ type Publisher {
 }
 
 type Query {
+  PersonByLocation(first: Int, location: _Neo4jPointInput, offset: Int): [Person0!]!
 }
 
 type _Neo4jDate {
@@ -1155,6 +1288,42 @@ type _Neo4jLocalTime {
   second: Int
 }
 
+type _Neo4jPoint {
+  # The coordinate reference systems (CRS)
+  # -------------------------------------
+  # posible values:
+  # * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+  #   * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+  #   * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+  # * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+  #   * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+  #   * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+  # * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+  # * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  crs: String
+  # The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)
+  height: Float
+  # The second element of the Coordinate for geographic CRS, degrees North of the equator
+  # Range -90.0 to 90.0
+  latitude: Float
+  # The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+  # Range -180.0 to 180.0
+  longitude: Float
+  # The internal Neo4j ID for the CRS
+  # One of:
+  # * `4326`: represents CRS `wgs-84`
+  # * `4979`: represents CRS `wgs-84-3d`
+  # * `7203`: represents CRS `cartesian`
+  # * `9157`: represents CRS `cartesian-3d`
+  srid: Int
+  # The first element of the Coordinate
+  x: Float
+  # The second element of the Coordinate
+  y: Float
+  # The third element of the Coordinate
+  z: Float
+}
+
 type _Neo4jTime {
   formatted: String
   hour: Int
@@ -1165,6 +1334,14 @@ type _Neo4jTime {
   second: Int
   timezone: String
 }
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+scalar DynamicProperties
 
 input _Neo4jDateInput {
   day: Int
@@ -1210,6 +1387,17 @@ input _Neo4jLocalTimeInput {
   second: Int
 }
 
+input _Neo4jPointInput {
+  crs: String
+  height: Float
+  latitude: Float
+  longitude: Float
+  srid: Int
+  x: Float
+  y: Float
+  z: Float
+}
+
 input _Neo4jTimeInput {
   formatted: String
   hour: Int
@@ -1221,15 +1409,8 @@ input _Neo4jTimeInput {
   timezone: String
 }
 
-enum RelationDirection {
-  IN
-  OUT
-  BOTH
-}
-
 directive @relation(name:String, direction: RelationDirection = OUT, from: String = "from", to: String = "to") on FIELD_DEFINITION | OBJECT
 directive @cypher(statement:String) on FIELD_DEFINITION
 directive @property(name:String) on FIELD_DEFINITION
 directive @dynamic(prefix:String = "properties.") on FIELD_DEFINITION
-scalar DynamicProperties
 ----

--- a/src/test/resources/filter-tests.adoc
+++ b/src/test/resources/filter-tests.adoc
@@ -15,6 +15,7 @@ type Person {
   fun: Boolean
   gender: Gender
   company: Company @relation(name:"WORKS_AT")
+  location: _Neo4jPoint
 }
 type Company {
   _id: ID
@@ -1109,6 +1110,279 @@ RETURN person { .name } AS person
 ----
 MATCH (person:Person)
 WHERE NOT person.fun = $filterPersonFun_NEQ
+RETURN person { .name } AS person
+----
+
+== Filter on spatial
+
+=== Filter spatial _eq_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { location: {longitude: 1, latitude: 2} }) { name }}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_EQ_longitude":1,
+  "filterPersonLocation_EQ_latitude":2
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person: Person)
+WHERE (person.location.longitude = $filterPersonLocation_EQ_longitude
+  AND person.location.latitude = $filterPersonLocation_EQ_latitude)
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _not_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { location_not: {longitude: 1, latitude: 2} }) { name }}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_NEQ_longitude":1,
+  "filterPersonLocation_NEQ_latitude":2
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person: Person)
+WHERE (NOT person.location.longitude = $filterPersonLocation_NEQ_longitude
+  AND NOT person.location.latitude = $filterPersonLocation_NEQ_latitude)
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _null_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { location: null }) { name }}
+----
+
+.Cypher Params
+[source,json]
+----
+{}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person: Person)
+WHERE person.location IS NULL
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _not_null_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { location_not: null }) { name }}
+----
+
+.Cypher Params
+[source,json]
+----
+{}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person: Person)
+WHERE person.location IS NOT NULL
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _distance eq_
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_DISTANCE": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE distance(person.location, point($filterPersonLocation_DISTANCE.point)) = $filterPersonLocation_DISTANCE.distance
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _distance lt_
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance_lt: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_DISTANCE_LT": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE distance(person.location, point($filterPersonLocation_DISTANCE_LT.point)) < $filterPersonLocation_DISTANCE_LT.distance
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _distance lte_
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance_lte: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_DISTANCE_LTE": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE distance(person.location, point($filterPersonLocation_DISTANCE_LTE.point)) <= $filterPersonLocation_DISTANCE_LTE.distance
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _distance gt_
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance_gt: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_DISTANCE_GT": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE distance(person.location, point($filterPersonLocation_DISTANCE_GT.point)) > $filterPersonLocation_DISTANCE_GT.distance
+RETURN person { .name } AS person
+----
+
+=== Filter spatial _distance gte_
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance_gte: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "filterPersonLocation_DISTANCE_GTE": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE distance(person.location, point($filterPersonLocation_DISTANCE_GTE.point)) >= $filterPersonLocation_DISTANCE_GTE.distance
 RETURN person { .name } AS person
 ----
 

--- a/src/test/resources/optimized-query-for-filter.adoc
+++ b/src/test/resources/optimized-query-for-filter.adoc
@@ -29,6 +29,7 @@ type Person {
   directedMovies: [Movie!]! @relation(name: "DIRECTED", direction:OUT)
   follows: [Person!]! @relation(name: "FOLLOWS", direction:OUT)
   followedBy: [Person!]! @relation(name: "FOLLOWS", direction:IN)
+  location: _Neo4jPoint
 }
 type Role @relation(name:"ACTED_IN", from:"actor", to:"movie") {
   actor: Person!
@@ -904,3 +905,148 @@ RETURN movie { .title } AS movie
 |The Polar Express
 |A League of Their Own
 |===
+
+=== Filter spatial not null
+
+.Query configuration
+[source,json,config=true]
+----
+{  "optimizedQuery":  ["FILTER_AS_MATCH"] }
+----
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_not: null}){
+    name
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:`Person`)
+WHERE person.location IS NOT NULL
+WITH person
+RETURN person { .name } AS person
+----
+
+=== Filter spatial null
+
+.Query configuration
+[source,json,config=true]
+----
+{  "optimizedQuery":  ["FILTER_AS_MATCH"] }
+----
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location: null}){
+    name
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:`Person`)
+WHERE person.location IS NULL
+WITH person
+RETURN person { .name } AS person
+----
+
+=== Filter spatial not
+
+.Query configuration
+[source,json,config=true]
+----
+{  "optimizedQuery":  ["FILTER_AS_MATCH"] }
+----
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_not: {longitude: 3, latitude: 3}}){
+    name
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "person_location_not_longitude": 3,
+  "person_location_not_latitude": 3
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:`Person`)
+WHERE (person.location.longitude <> $person_location_not_longitude
+  AND person.location.latitude <> $person_location_not_latitude)
+WITH person
+RETURN person { .name } AS person
+----
+
+=== Filter spatial distance
+
+.Query configuration
+[source,json,config=true]
+----
+{  "optimizedQuery":  ["FILTER_AS_MATCH"] }
+----
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  person(filter:{ location_distance_lt: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
+    name
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "person_location_distance_lt": {
+    "distance": 3,
+    "point": {
+      "longitude": 1,
+      "latitude": 2,
+      "height": 3
+    }
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:`Person`)
+WHERE distance(person.location, point($person_location_distance_lt.point)) < $person_location_distance_lt.distance
+WITH person
+RETURN person { .name } AS person
+----

--- a/src/test/resources/translator-tests1.adoc
+++ b/src/test/resources/translator-tests1.adoc
@@ -12,6 +12,7 @@ type Person {
   livedIn : [Location] @relation(name:"LIVED_IN", direction: OUT)
   born : Birth
   died : Death
+  location: _Neo4jPoint
 }
 interface Temporal {
   date: String
@@ -782,4 +783,98 @@ RETURN location {
   .cityArg,
   .villageArg
 } AS location
+----
+
+=== query spatial types
+
+.GraphQL-Query
+[source,graphql]
+----
+query {
+  person(location:{longitude: 1, latitude: 2 }){
+    name
+    location {
+      crs
+      longitude
+      latitude
+      height
+    }
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "personLocationLongitude": 1,
+  "personLocationLatitude": 2
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person: Person)
+WHERE person.location.longitude = $personLocationLongitude
+AND  person.location.latitude = $personLocationLatitude
+RETURN person {
+  .name,
+  location: {
+    crs: person.location.crs,
+    longitude: person.location.longitude,
+    latitude: person.location.latitude,
+    height: person.location.height
+  }
+} AS person
+----
+
+=== mutate spatial types
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation{
+  createPerson(name:"Test2", location:{x: 1, y: 2, z: 3, crs: "wgs-84-3d"}){
+    name
+    location{
+      crs
+      srid
+      latitude
+      longitude
+      height
+    }
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "createPersonName": "Test2",
+  "createPersonLocation": {
+    "x":1,
+    "y":2,
+    "z": 3,
+    "crs": "wgs-84-3d"
+  }
+}
+----
+
+.Cypher
+[source,cypher]
+----
+CREATE (createPerson:Person { name: $createPersonName, location: point($createPersonLocation) })
+WITH createPerson
+RETURN createPerson {
+  .name,
+  location: {
+    crs: createPerson.location.crs,
+    srid: createPerson.location.srid,
+    latitude: createPerson.location.latitude,
+    longitude: createPerson.location.longitude,
+    height: createPerson.location.height
+  }
+} AS createPerson
 ----


### PR DESCRIPTION
This PR add support for [spatials](https://neo4j.com/docs/cypher-manual/3.5/syntax/spatial/#cypher-spatial-crs-geographic) and [distance comparisons](https://neo4j.com/docs/cypher-manual/3.5/functions/spatial/#functions-distance).

Now you can rund queries like:

```graphql
query {
  person(location:{longitude: 1, latitude: 2 }){
    name
    location {
      crs
      longitude
      latitude
      height
    }
  }
}
```

or 

```graphql
{
  person(filter:{ location_distance_gte: { distance: 3, point: {longitude: 1, latitude:2, height: 3}}}){
    name
  }
}
```
resolves #11