### PR TITLE
Fixes the issue that an update removes the custom ID field on the node

### DIFF
--- a/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
+++ b/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
@@ -31,7 +31,7 @@ class MergeOrUpdateHandler private constructor(
         }
 
         override fun createDataFetcher(rootType: GraphQLObjectType, fieldDefinition: GraphQLFieldDefinition): DataFetcher<Cypher>? {
-            if (rootType.name != MUTATION){
+            if (rootType.name != MUTATION) {
                 return null
             }
             if (fieldDefinition.cypherDirective() != null) {
@@ -67,8 +67,13 @@ class MergeOrUpdateHandler private constructor(
     }
 
     init {
-        defaultFields.clear()
-        propertyFields.remove(idField.name) // id should not be updated
+        defaultFields.clear() // for marge or updates we do not reset to defaults
+        if (idField.isNativeId() || merge) {
+            // native id cannot be updated
+            // if the ID is not a native ID and we are in the update mode, we do not remove it from the properties
+            // b/c otherwise the id field will be unset
+            propertyFields.remove(idField.name)
+        }
     }
 
     override fun generateCypher(variable: String, field: Field, env: DataFetchingEnvironment): Cypher {

--- a/src/test/resources/dynamic-property-tests.adoc
+++ b/src/test/resources/dynamic-property-tests.adoc
@@ -105,6 +105,7 @@ mutation {
 ----
 MATCH (updatePerson:Person { id: $updatePersonId })
 SET updatePerson = {
+  id: $updatePersonId,
   `properties.foo`: $updatePersonJsonFoo,
   `properties.x`: $updatePersonJsonX
 }


### PR DESCRIPTION
We forgot to pass the id, when updating a node. This causes the id to be unset.
This PR resolves #95 