### PR TITLE
Add support for custom scalars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
             <artifactId>neo4j-opencypher-dsl</artifactId>
             <version>1.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/readme.adoc
+++ b/readme.adoc
@@ -83,6 +83,7 @@ You find more usage examples in the:
 * link:src/test/resources/translator-tests1.adoc[Translator 1 TCK]
 * link:src/test/resources/translator-tests2.adoc[Translator 2 TCK]
 * link:src/test/resources/translator-tests3.adoc[Translator 3 TCK]
+* link:src/test/resources/translator-tests-custom-scalars.adoc[Translator custom scalars TCK]
 * link:src/test/resources/optimized-query-for-filter.adoc[Alternative Filter TCK]
 
 == Demo
@@ -246,6 +247,7 @@ This example doesn't handle introspection queries, but the one in the test direc
 * date(time)
 * interfaces
 * complex filter parameters, with optional query optimization strategy
+* scalars
 
 === Next
 
@@ -253,7 +255,6 @@ This example doesn't handle introspection queries, but the one in the test direc
 * sorting (nested)
 * input types
 * unions
-* scalars
 * spatial
 
 == Documentation

--- a/src/main/kotlin/org/neo4j/graphql/NoOpCoercing.kt
+++ b/src/main/kotlin/org/neo4j/graphql/NoOpCoercing.kt
@@ -1,0 +1,11 @@
+package org.neo4j.graphql
+
+import graphql.schema.Coercing
+
+object NoOpCoercing : Coercing<Any, Any> {
+    override fun parseLiteral(input: Any?) = input
+
+    override fun serialize(dataFetcherResult: Any?) = dataFetcherResult
+
+    override fun parseValue(input: Any?) = input
+}

--- a/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
+++ b/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
@@ -30,5 +30,8 @@ class CypherTests {
     fun `translator-tests3`() = CypherTestSuite("translator-tests3.adoc").run()
 
     @TestFactory
+    fun `translator-tests-custom-scalars`() = CypherTestSuite("translator-tests-custom-scalars.adoc").run()
+
+    @TestFactory
     fun `optimized-query-for-filter`() = CypherTestSuite("optimized-query-for-filter.adoc").run()
 }

--- a/src/test/resources/translator-tests-custom-scalars.adoc
+++ b/src/test/resources/translator-tests-custom-scalars.adoc
@@ -1,0 +1,202 @@
+:toc:
+
+= Translator Tests
+
+== Schema
+
+[source,graphql,schema=true]
+----
+scalar Date
+type Movie {
+  _id: ID!
+  title: String!
+  released: Date
+}
+----
+
+== Tests
+
+=== Create
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+  createMovie(title:"Forrest Gump", released: 1994) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "createMovieTitle": "Forrest Gump",
+  "createMovieReleased": 1994
+}
+----
+
+.Cypher
+[source,cypher]
+----
+CREATE (createMovie:Movie { title: $createMovieTitle, released: $createMovieReleased })
+WITH createMovie
+RETURN createMovie { .title, .released } AS createMovie
+----
+
+=== Update
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+  updateMovie(_id: 1, released: 1995) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "updateMovie_id": 1,
+  "updateMovieReleased": 1995
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (updateMovie: Movie)
+WHERE ID(updateMovie) = toInteger($updateMovie_id)
+SET updateMovie = { released: $updateMovieReleased }
+WITH updateMovie
+RETURN updateMovie { .title, .released } AS updateMovie
+----
+
+=== Merge
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+  mergeMovie(_id: 1, released: 1995) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "mergeMovie_id": 1,
+  "mergeMovieReleased": 1995
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (mergeMovie: Movie)
+WHERE ID(mergeMovie) = toInteger($mergeMovie_id)
+SET mergeMovie += { released: $mergeMovieReleased }
+WITH mergeMovie
+RETURN mergeMovie { .title, .released } AS mergeMovie
+----
+
+=== Merge null
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+  updateMovie(_id: 1, released: null) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "updateMovie_id": 1,
+  "updateMovieReleased": null
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (updateMovie: Movie)
+WHERE ID(updateMovie) = toInteger($updateMovie_id)
+SET updateMovie = { released: $updateMovieReleased }
+WITH updateMovie
+RETURN updateMovie { .title, .released } AS updateMovie
+----
+
+=== Find
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  movie(released: 1994) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "movieReleased": 1994
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (movie: Movie)
+WHERE movie.released = $movieReleased
+RETURN movie { .title, .released } AS movie
+----
+
+=== Filter
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  movie(filter:{released_gte: 1994}) {
+    title
+    released
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "filterMovieReleased_GTE": 1994
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (movie: Movie)
+WHERE movie.released >= $filterMovieReleased_GTE
+RETURN movie { .title, .released } AS movie
+----
+


### PR DESCRIPTION
This PR add support for custom scalars

For the given schema:

```graphql
scalar Date
type Movie {
  _id: ID!
  title: String!
  released: Date
}
```

you can now run queries like:

```graphql
{
  movie(filter:{released_gte: 1994}) {
    title
    released
  }
}
```

resolves #9