### PR TITLE
Prevent use of variables when limit and offset are specified directly as numbers

### DIFF
--- a/src/test/resources/movie-tests.adoc
+++ b/src/test/resources/movie-tests.adoc
@@ -201,9 +201,7 @@ RETURN movie { .title } AS movie
 [source,json]
 ----
 {
-  "movieTitle": "River Runs Through It, A",
-  "movieOffset": 1,
-  "movieFirst": 1
+  "movieTitle": "River Runs Through It, A"
 }
 ----
 
@@ -214,7 +212,7 @@ RETURN movie { .title } AS movie
 MATCH (movie:Movie) 
 WHERE movie.title = $movieTitle 
 RETURN movie { .title, .year } AS movie 
-SKIP $movieOffset LIMIT $movieFirst
+SKIP 1 LIMIT 1
 ----
 
 === Query Single Relation
@@ -344,8 +342,7 @@ RETURN movie {
 [source,json]
 ----
 {
-  "movieTitle": "River Runs Through It, A",
-  "movieActorsFirst": 3
+  "movieTitle": "River Runs Through It, A"
 }
 ----
 
@@ -356,7 +353,7 @@ MATCH (movie:Movie)
 WHERE movie.title = $movieTitle 
 RETURN movie {
   .title,
-  actors:[(movie)<-[:ACTED_IN]-(movieActors:Actor) | movieActors { .name }][0..$movieActorsFirst]
+  actors:[(movie)<-[:ACTED_IN]-(movieActors:Actor) | movieActors { .name }][0..3]
 } AS movie
 ----
 
@@ -421,8 +418,7 @@ RETURN movie {
 ----
 {
   "movieFirst": 3,
-  "movieOffset": 0,
-  "movieSimilarFirst": 3
+  "movieOffset": 0
 }
 ----
 
@@ -439,7 +435,7 @@ RETURN movie {
       offset:$movieOffset
     }) | movieSimilar {
       .title
-    }][0..$movieSimilarFirst]
+    }][0..3]
 } AS movie
 ----
 
@@ -462,8 +458,7 @@ RETURN movie {
 [source,json]
 ----
 {
-  "genresBySubstringSubstring": "Action",
-  "genresBySubstringMoviesFirst": 3
+  "genresBySubstringSubstring": "Action"
 }
 ----
 
@@ -473,7 +468,7 @@ RETURN movie {
 UNWIND apoc.cypher.runFirstColumnMany('WITH $substring AS substring MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g', { substring:$genresBySubstringSubstring }) AS genresBySubstring
 RETURN genresBySubstring {
   .name,
-  movies:[(genresBySubstring)<-[:IN_GENRE]-(genresBySubstringMovies:Movie) | genresBySubstringMovies { .title }][0..$genresBySubstringMoviesFirst]
+  movies:[(genresBySubstring)<-[:IN_GENRE]-(genresBySubstringMovies:Movie) | genresBySubstringMovies { .title }][0..3]
 } AS genresBySubstring
 ----
 
@@ -584,8 +579,7 @@ RETURN movie {
   "movieTitle": "River Runs Through It, A", 
   "movieActorsMoviesActorsName": "Tom Hanks", 
   "movieActorsMoviesActorsMoviesFirst": 3, 
-  "movieActorsMoviesActorsMoviesOffset": 0,
-  "movieActorsMoviesActorsMoviesSimilarFirst": 3
+  "movieActorsMoviesActorsMoviesOffset": 0
 }
 ----
 
@@ -601,7 +595,7 @@ RETURN movie { .title, actors:[(movie)<-[:ACTED_IN]-(movieActors:Actor) |
              movieActorsMoviesActors { .name, movies:[(movieActorsMoviesActors)-[:ACTED_IN]->(movieActorsMoviesActorsMovies:Movie) |
                movieActorsMoviesActorsMovies { .title, .year, similar:[movieActorsMoviesActorsMoviesSimilar
                  IN apoc.cypher.runFirstColumnMany('WITH $this AS this, $first AS first, $offset AS offset MATCH (this)--(:Genre)--(o:Movie) RETURN o', { this:movieActorsMoviesActorsMovies, first:$movieActorsMoviesActorsMoviesFirst, offset:$movieActorsMoviesActorsMoviesOffset }) |
-                   movieActorsMoviesActorsMoviesSimilar { .title, .year }][0..$movieActorsMoviesActorsMoviesSimilarFirst] }] }] }] }] } AS movie
+                   movieActorsMoviesActorsMoviesSimilar { .title, .year }][0..3] }] }] }] }] } AS movie
 ----
 
 === Should merge an actor by the userId
@@ -818,8 +812,7 @@ RETURN add { .name } AS add
 [source,json]
 ----
 {
-  "movieYear": 2010,
-  "movieFirst": 10
+  "movieYear": 2010
 }
 ----
 
@@ -830,7 +823,7 @@ MATCH (movie:Movie)
 WHERE movie.year = $movieYear 
 RETURN movie { .title } AS movie 
 ORDER BY movie.title DESC  
-LIMIT $movieFirst
+LIMIT 10
 ----
 
 === Descending, number
@@ -844,9 +837,7 @@ LIMIT $movieFirst
 .Cypher Params
 [source,json]
 ----
-{
-  "movieFirst": 10
-}
+{}
 ----
 
 .Cypher
@@ -854,7 +845,7 @@ LIMIT $movieFirst
 ----
 MATCH  (movie:Movie)
 RETURN  movie  {  .title  } AS  movie
-ORDER BY movie.year DESC LIMIT $movieFirst
+ORDER BY movie.year DESC LIMIT 10
 ----
 
 === Find all relations

--- a/src/test/resources/translator-tests1.adoc
+++ b/src/test/resources/translator-tests1.adoc
@@ -76,7 +76,7 @@ MATCH (person:Person) RETURN person { .age } AS person ORDER BY person.name ASC
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name } } } }
+ { person { name born { date to { name } } } }
 ----
 
 .Cypher params
@@ -96,7 +96,7 @@ MATCH (person:Person) RETURN person { .name, born:[(person)-[personBorn:BORN]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livedIn { name } } }
+ { person { name age livedIn { name } } }
 ----
 
 .Cypher params
@@ -142,16 +142,14 @@ MATCH (person:Person) RETURN person { .name } AS person
 .Cypher params
 [source,json]
 ----
-{
-  "personOffset": 3
-}
+{}
 ----
 
 .Cypher
 [source,cypher]
 ----
 MATCH (person:Person)
-RETURN person { .age } AS person SKIP $personOffset
+RETURN person { .age } AS person SKIP 3
 ----
 
 === query offset as variable
@@ -188,12 +186,48 @@ query getPersons($offset: Int){
 MATCH (person:Person) RETURN person { .age } AS person SKIP $personOffset
 ----
 
+=== query offset and limit as variable
+
+.GraphQL-Query
+[source,graphql]
+----
+query getPersons($offset: Int, $limit: Int){
+  person(offset: $offset, first: $limit) {
+    age
+  }
+}
+----
+
+.Query variables
+[source,json,request=true]
+----
+{
+  "offset": 10,
+  "limit": 8
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "personOffset": 10,
+  "personFirst": 8
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person) RETURN person { .age } AS person SKIP $personOffset LIMIT $personFirst
+----
+
 === nested query
 
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn { name } } }
+ { person { name age livesIn { name } } }
 ----
 
 .Cypher params
@@ -213,7 +247,7 @@ MATCH (person:Person) RETURN person { .name, .age, livesIn:[(person)-[:LIVES_IN]
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age } }
+ { person { name age } }
 ----
 
 .Cypher params
@@ -253,7 +287,7 @@ MATCH (person:Person) RETURN person { .name } AS person
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name died { date where { name } } } }
+ { person { name died { date where { name } } } }
 ----
 
 .Cypher params
@@ -273,7 +307,7 @@ MATCH (person:Person) RETURN person { .name, died:[(person)-[personDied:DIED]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name founded { name } } } } }
+ { person { name born { date to { name founded { name } } } } }
 ----
 
 .Cypher params
@@ -305,7 +339,7 @@ RETURN person {
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name founded { name born { date to { name } } } } } } }
+ { person { name born { date to { name founded { name born { date to { name } } } } } } }
 ----
 
 .Cypher params
@@ -325,7 +359,7 @@ MATCH (person:Person) RETURN person { .name, born:[(person)-[personBorn:BORN]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn(name:"Berlin") { name } } }
+ { person { name age livesIn(name:"Berlin") { name } } }
 ----
 
 .Cypher params
@@ -385,7 +419,7 @@ MATCH (person:Person) RETURN person { .name, .age } AS person
 .GraphQL-Query
 [source,graphql]
 ----
- { foo:person { n:name } }
+ { foo:person { n:name } }
 ----
 
 .Cypher params
@@ -411,16 +445,14 @@ MATCH (foo:Person) RETURN foo { n:foo.name } AS foo
 .Cypher params
 [source,json]
 ----
-{
-  "personFirst": 2
-}
+{}
 ----
 
 .Cypher
 [source,cypher]
 ----
 MATCH (person:Person)
-RETURN person { .age } AS person LIMIT $personFirst
+RETURN person { .age } AS person LIMIT 2
 ----
 
 === simple query where
@@ -485,23 +517,18 @@ WHERE p._param = $_param
 RETURN p { .age } AS p
 ----
 
-SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
-SLF4J: Defaulting to no-operation (NOP) logger implementation
-SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
 === nested query slice offset
 
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(offset:3) { name } } }
+ { person { livedIn(offset:3) { name } } }
 ----
 
 .Cypher params
 [source,json]
 ----
-{
-  "personLivedInOffset": 3
-}
+{}
 ----
 
 .Cypher
@@ -511,7 +538,7 @@ MATCH (person:Person)
 RETURN person {
   livedIn:[(person)-[:LIVED_IN]->(personLivedIn:Location) | personLivedIn {
     .name
-  }][$personLivedInOffset..]
+  }][3..]
 } AS person
 ----
 
@@ -520,15 +547,13 @@ RETURN person {
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(first:2) { name } } }
+ { person { livedIn(first:2) { name } } }
 ----
 
 .Cypher params
 [source,json]
 ----
-{
-  "personLivedInFirst": 2
-}
+{}
 ----
 
 .Cypher
@@ -538,18 +563,16 @@ MATCH (person:Person)
 RETURN person {
   livedIn:[(person)-[:LIVED_IN]->(personLivedIn:Location) | personLivedIn {
     .name
-  }][0..$personLivedInFirst]
+  }][0..2]
 } AS person
 ----
 
-line 1:15 token recognition error at: ' '
-line 1:35 token recognition error at: ' '
 === nested query 2 nd hop
 
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn { name founded {name}} } }
+ { person {name age livesIn { name founded {name}}} }
 ----
 
 .Cypher params
@@ -564,7 +587,7 @@ line 1:35 token recognition error at: ' '
 MATCH (person:Person) RETURN person { .name, .age, livesIn:[(person)-[:LIVES_IN]->(personLivesIn:Location) | personLivesIn { .name, founded:[(personLivesIn)<-[:FOUNDED]-(personLivesInFounded:Person) | personLivesInFounded { .name }][0] }][0] } AS person
 ----
 
-line 1:12 token recognition error at: ' '
+line 1:12 token recognition error at: ' '
 === inline fragment multi fields
 
 .GraphQL-Query
@@ -596,17 +619,14 @@ MATCH (person:Person) RETURN person { .name, .age } AS person
 .Cypher params
 [source,json]
 ----
-{
-  "personFirst": 2,
-  "personOffset": 3
-}
+{}
 ----
 
 .Cypher
 [source,cypher]
 ----
 MATCH (person:Person)
-RETURN person { .age } AS person SKIP $personOffset LIMIT $personFirst
+RETURN person { .age } AS person SKIP 3 LIMIT 2
 ----
 
 === nested query slice first offset
@@ -614,15 +634,51 @@ RETURN person { .age } AS person SKIP $personOffset LIMIT $personFirst
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(first:2,offset:3) { name } } }
+ { person { livedIn(first:2,offset:3) { name } } }
+----
+
+.Cypher params
+[source,json]
+----
+{}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+RETURN person {
+  livedIn:[(person)-[:LIVED_IN]->(personLivedIn:Location) | personLivedIn {
+    .name
+  }][3..5]
+} AS person
+----
+
+=== nested query slice first offset as variables
+
+.GraphQL-Query
+[source,graphql]
+----
+ query person($first: Int, $offset: Int){
+  person { livedIn(first:$first,offset:$offset) { name } }
+}
+----
+
+.Query variables
+[source,json,request=true]
+----
+{
+  "offset": 3,
+  "first": 2
+}
 ----
 
 .Cypher params
 [source,json]
 ----
 {
-  "personLivedInOffset": 3,
-  "personLivedInFirst": 2
+  "personLivedInFirst": 2,
+  "personLivedInOffset": 3
 }
 ----
 
@@ -633,7 +689,7 @@ MATCH (person:Person)
 RETURN person {
   livedIn:[(person)-[:LIVED_IN]->(personLivedIn:Location) | personLivedIn {
     .name
-  }][$personLivedInOffset.. $personLivedInOffset + $personLivedInFirst]
+  }][$personLivedInOffset..$personLivedInOffset + $personLivedInFirst]
 } AS person
 ----
 


### PR DESCRIPTION
This change prevents the use of variables when limit and offset are specified directly as numbers.

Prior this change the graphql query:

```graphql
{ person:person(first:2,offset:3) { age } }
```

resulted in 

```cypher
MATCH (person:Person)
RETURN person { .age } AS person SKIP $personOffset LIMIT $personFirst
```

after this change the following cypher will be generated:

```cypher
MATCH (person:Person)
RETURN person { .age } AS person SKIP 3 LIMIT 2
```

This simplifies testing, as the generated cypher can be used directly in the neo4j browser without the manual step of replacing the variables for limit and offset