### PR TITLE
This change fixes an issue where properties got unset for when updating a node

### DIFF
--- a/src/test/resources/dynamic-property-tests.adoc
+++ b/src/test/resources/dynamic-property-tests.adoc
@@ -104,8 +104,7 @@ mutation {
 [source,cypher]
 ----
 MATCH (updatePerson:Person { id: $updatePersonId })
-SET updatePerson = {
-  id: $updatePersonId,
+SET updatePerson += {
   `properties.foo`: $updatePersonJsonFoo,
   `properties.x`: $updatePersonJsonX
 }
@@ -209,7 +208,7 @@ mutation {
 ----
 MATCH ()-[updateKnows:KNOWS]->()
 WHERE ID(updateKnows) = toInteger($updateKnows_id)
-SET updateKnows = { `prefix.foo`: $updateKnowsJsonFoo }
+SET updateKnows += { `prefix.foo`: $updateKnowsJsonFoo }
 WITH updateKnows
 RETURN updateKnows {
   json:apoc.map.fromPairs([key IN keys(updateKnows) WHERE key STARTS WITH 'prefix.'| [substring(key,7), updateKnows[key]]])

--- a/src/test/resources/movie-tests.adoc
+++ b/src/test/resources/movie-tests.adoc
@@ -940,7 +940,7 @@ mutation {
 ----
 MATCH ()-[updateRated:RATED]->()
 WHERE ID(updateRated) = toInteger($updateRated_id)
-SET updateRated = { rating: $updateRatedRating }
+SET updateRated += { rating: $updateRatedRating }
 WITH updateRated
 RETURN updateRated { .rating } AS updateRated
 ----

--- a/src/test/resources/translator-tests-custom-scalars.adoc
+++ b/src/test/resources/translator-tests-custom-scalars.adoc
@@ -73,7 +73,7 @@ mutation {
 ----
 MATCH (updateMovie: Movie)
 WHERE ID(updateMovie) = toInteger($updateMovie_id)
-SET updateMovie = { released: $updateMovieReleased }
+SET updateMovie += { released: $updateMovieReleased }
 WITH updateMovie
 RETURN updateMovie { .title, .released } AS updateMovie
 ----
@@ -137,7 +137,7 @@ mutation {
 ----
 MATCH (updateMovie: Movie)
 WHERE ID(updateMovie) = toInteger($updateMovie_id)
-SET updateMovie = { released: $updateMovieReleased }
+SET updateMovie += { released: $updateMovieReleased }
 WITH updateMovie
 RETURN updateMovie { .title, .released } AS updateMovie
 ----


### PR DESCRIPTION
Now we always use `SET x += {}` to update properties.

fixes #105 