### PR TITLE
Add ability to print out additional debug information for cypher-tests

### DIFF
--- a/src/test/kotlin/org/neo4j/graphql/utils/CypherTestSuite.kt
+++ b/src/test/kotlin/org/neo4j/graphql/utils/CypherTestSuite.kt
@@ -104,6 +104,6 @@ class CypherTestSuite(fileName: String) : AsciiDocTestSuite(fileName) {
     }
 
     companion object {
-        const val DEBUG = false
+        val DEBUG = System.getProperty("neo4j-graphql-java.debug", "false") == "true"
     }
 }


### PR DESCRIPTION
AS requested by https://github.com/neo4j-graphql/neo4j-graphql-java/pull/114#issuecomment-683479125