### PR TITLE
This bugfix solves a problem where inverse relationships were incorrectly mapped

### DIFF
--- a/src/test/resources/relationship-tests.adoc
+++ b/src/test/resources/relationship-tests.adoc
@@ -329,8 +329,8 @@ RETURN team {
 MATCH (player: Player)
 RETURN player {
   .id,
-  memberships: [(player)<-[playerMemberships: MEMBER_OF]-(playerMembershipsPlayer: Player) | playerMemberships {
-    team: playerMembershipsPlayer { .id },
+  memberships: [(player)-[playerMemberships: MEMBER_OF]->(playerMembershipsTeam: Team) | playerMemberships {
+    team: playerMembershipsTeam { .id },
     .prop
   }]
 } AS player

--- a/src/test/resources/translator-tests1.adoc
+++ b/src/test/resources/translator-tests1.adoc
@@ -77,7 +77,7 @@ MATCH (person:Person) RETURN person { .age } AS person ORDER BY person.name ASC
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name } } } }
+{ person { name born { date to { name } } } }
 ----
 
 .Cypher params
@@ -97,7 +97,7 @@ MATCH (person:Person) RETURN person { .name, born:[(person)-[personBorn:BORN]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livedIn { name } } }
+{ person { name age livedIn { name } } }
 ----
 
 .Cypher params
@@ -194,7 +194,7 @@ MATCH (person:Person) RETURN person { .age } AS person SKIP $personOffset
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn { name } } }
+{ person { name age livesIn { name } } }
 ----
 
 .Cypher params
@@ -214,7 +214,7 @@ MATCH (person:Person) RETURN person { .name, .age, livesIn:[(person)-[:LIVES_IN]
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age } }
+{ person { name age } }
 ----
 
 .Cypher params
@@ -254,7 +254,7 @@ MATCH (person:Person) RETURN person { .name } AS person
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name died { date where { name } } } }
+{ person { name died { date where { name } } } }
 ----
 
 .Cypher params
@@ -274,7 +274,7 @@ MATCH (person:Person) RETURN person { .name, died:[(person)-[personDied:DIED]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name founded { name } } } } }
+{ person { name born { date to { name founded { name } } } } }
 ----
 
 .Cypher params
@@ -306,7 +306,7 @@ RETURN person {
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name born { date to { name founded { name born { date to { name } } } } } } }
+{ person { name born { date to { name founded { name born { date to { name } } } } } } }
 ----
 
 .Cypher params
@@ -326,7 +326,7 @@ MATCH (person:Person) RETURN person { .name, born:[(person)-[personBorn:BORN]->(
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn(name:"Berlin") { name } } }
+{ person { name age livesIn(name:"Berlin") { name } } }
 ----
 
 .Cypher params
@@ -408,7 +408,7 @@ MATCH (person:Person) RETURN person { .name, .age } AS person
 .GraphQL-Query
 [source,graphql]
 ----
- { foo:person { n:name } }
+{ foo:person {n:name } }
 ----
 
 .Cypher params
@@ -516,7 +516,7 @@ SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further detail
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(offset:3) { name } } }
+{ person { livedIn(offset:3) { name } } }
 ----
 
 .Cypher params
@@ -543,7 +543,7 @@ RETURN person {
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(first:2) { name } } }
+{ person { livedIn(first:2) { name } } }
 ----
 
 .Cypher params
@@ -565,14 +565,12 @@ RETURN person {
 } AS person
 ----
 
-line 1:15 token recognition error at: ' '
-line 1:35 token recognition error at: ' '
 === nested query 2 nd hop
 
 .GraphQL-Query
 [source,graphql]
 ----
- { person { name age livesIn { name founded {name}} } }
+{ person { name age livesIn { name founded {name}} } }
 ----
 
 .Cypher params
@@ -587,13 +585,12 @@ line 1:35 token recognition error at: ' '
 MATCH (person:Person) RETURN person { .name, .age, livesIn:[(person)-[:LIVES_IN]->(personLivesIn:Location) | personLivesIn { .name, founded:[(personLivesIn)<-[:FOUNDED]-(personLivesInFounded:Person) | personLivesInFounded { .name }][0] }][0] } AS person
 ----
 
-line 1:12 token recognition error at: ' '
 === inline fragment multi fields
 
 .GraphQL-Query
 [source,graphql]
 ----
- query { person { ... on Person { name,age } } }
+query { person { ... on Person { name,age } } }
 ----
 
 .Cypher params
@@ -637,7 +634,7 @@ RETURN person { .age } AS person SKIP $personOffset LIMIT $personFirst
 .GraphQL-Query
 [source,graphql]
 ----
- { person { livedIn(first:2,offset:3) { name } } }
+{ person { livedIn(first:2,offset:3) { name } } }
 ----
 
 .Cypher params


### PR DESCRIPTION
```graphql
{
  player{
    id
    memberships {
      team {
        id
      }
      prop
    }
  }
}
```

was mapped to

```cypher
MATCH (player: Player)
RETURN player {
  .id,
  memberships: [(player)<-[playerMemberships: MEMBER_OF]-(playerMembershipsPlayer: Player) | playerMemberships {
    team: playerMembershipsPlayer { .id },
    .prop
  }]
} AS player
```

but

```cypher
MATCH (player: Player)
RETURN player {
  .id,
  memberships: [(player)-[playerMemberships: MEMBER_OF]->(playerMembershipsTeam: Team) | playerMemberships {
    team: playerMembershipsTeam { .id },
    .prop
  }]
} AS player
```
is expected