### PR TITLE
Separate sorting and paging into own input type

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/SchemaConfig.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/SchemaConfig.kt
@@ -6,7 +6,24 @@ data class SchemaConfig @JvmOverloads constructor(
         /**
          * if true, the top level fields of the Query-type will be capitalized
          */
-        val capitalizeQueryFields: Boolean = false
+        val capitalizeQueryFields: Boolean = false,
+        /**
+         * Defines the way the input for queries and mutations are generated
+         */
+        val queryOptionStyle: InputStyle = InputStyle.ARGUMENT_PER_FIELD,
 ) {
     data class CRUDConfig(val enabled: Boolean = true, val exclude: List<String> = emptyList())
+
+    enum class InputStyle {
+        /**
+         * Separate arguments are generated for the query and / or mutation fields
+         */
+        @Deprecated(message = "Will be removed in the next major release", replaceWith = ReplaceWith(expression = "INPUT_TYPE"))
+        ARGUMENT_PER_FIELD,
+
+        /**
+         * All fields are encapsulated into an input type used as one argument in query and / or mutation fields
+         */
+        INPUT_TYPE,
+    }
 }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcherForContainer.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcherForContainer.kt
@@ -23,7 +23,7 @@ abstract class BaseDataFetcherForContainer(
     init {
         fieldDefinition
             .arguments
-            .filterNot { listOf(FIRST, OFFSET, ORDER_BY, NATIVE_ID).contains(it.name) }
+            .filterNot { listOf(FIRST, OFFSET, ORDER_BY, NATIVE_ID, OPTIONS).contains(it.name) }
             .onEach { arg ->
                 if (arg.defaultValue != null) {
                     defaultFields[arg.name] = arg.defaultValue

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/CypherDirectiveHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/CypherDirectiveHandler.kt
@@ -50,7 +50,7 @@ class CypherDirectiveHandler(
         } else {
             query.returning(node.`as`(field.aliasOrName()))
         }
-        val ordering = orderBy(node, field.arguments, fieldDefinition)
+        val ordering = orderBy(node, field.arguments, fieldDefinition, env.variables)
         val skipLimit = SkipLimit(variable, field.arguments, fieldDefinition)
 
         val resultWithSkipLimit = readingWithWhere

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
@@ -41,7 +41,7 @@ class OptimizedFilterHandler(val type: GraphQLFieldsContainer) : ProjectionBase(
 
         var ongoingReading: OngoingReading? = null
 
-        val filteredArguments = field.arguments.filterNot { setOf(FIRST, OFFSET, ORDER_BY, FILTER).contains(it.name) }
+        val filteredArguments = field.arguments.filterNot { SPECIAL_FIELDS.contains(it.name) }
         if (filteredArguments.isNotEmpty()) {
             val parsedQuery = QueryParser.parseArguments(filteredArguments, fieldDefinition, type, variables)
             val condition = handleQuery(variable, "", rootNode, parsedQuery, type, variables)

--- a/core/src/main/kotlin/org/neo4j/graphql/parser/QueryParser.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/parser/QueryParser.kt
@@ -125,7 +125,7 @@ object QueryParser {
         fieldDefinition.arguments
             .filter { it.defaultValue != null }
             .filterNot { queriedFields.containsKey(it.name) }
-            .filterNot { setOf(ProjectionBase.FIRST, ProjectionBase.OFFSET, ProjectionBase.ORDER_BY, ProjectionBase.FILTER).contains(it.name) }
+            .filterNot { ProjectionBase.SPECIAL_FIELDS.contains(it.name) }
             .forEach { argument ->
                 queriedFields[argument.name] = index++ to ObjectField(argument.name, argument.defaultValue.asGraphQLValue())
             }

--- a/core/src/main/resources/neo4j_types.graphql
+++ b/core/src/main/resources/neo4j_types.graphql
@@ -4,6 +4,13 @@ enum RelationDirection {
   BOTH
 }
 
+enum SortDirection {
+  """Sort by field values in ascending order."""
+  ASC
+  """Sort by field values in descending order."""
+  DESC
+}
+
 scalar DynamicProperties
 
 type _Neo4jTime {

--- a/core/src/test/kotlin/org/neo4j/graphql/AugmentationTests.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/AugmentationTests.kt
@@ -1,7 +1,12 @@
 package org.neo4j.graphql
 
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.TestFactory
 import org.neo4j.graphql.utils.GraphQLSchemaTestSuite
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.stream.Stream
 
 class AugmentationTests {
 
@@ -10,4 +15,15 @@ class AugmentationTests {
 
     @TestFactory
     fun `schema-operations-tests`() = GraphQLSchemaTestSuite("schema-operations-tests.adoc").generateTests()
+
+    @TestFactory
+    fun `schema augmentation tests`(): Stream<DynamicNode>? = Files
+        .list(Paths.get("src/test/resources/tck-test-files/schema"))
+        .map {
+            DynamicContainer.dynamicContainer(
+                    it.fileName.toString(),
+                    it.toUri(),
+                    GraphQLSchemaTestSuite("tck-test-files/schema/${it.fileName}").generateTests()
+            )
+        }
 }

--- a/core/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
@@ -81,7 +81,19 @@ class CypherTests {
             )
         }
 
+
+    @TestFactory
+    fun `new cypher tck tests`(): Stream<DynamicNode>? = Files
+        .list(Paths.get("src/test/resources/tck-test-files/cypher"))
+        .map {
+            DynamicContainer.dynamicContainer(
+                    it.fileName.toString(),
+                    it.toUri(),
+                    CypherTestSuite("tck-test-files/cypher/${it.fileName}", neo4j).generateTests()
+            )
+        }
+
     companion object {
-       private val INTEGRATION_TESTS = System.getProperty("neo4j-graphql-java.integration-tests", "false") == "true"
+        private val INTEGRATION_TESTS = System.getProperty("neo4j-graphql-java.integration-tests", "false") == "true"
     }
 }

--- a/core/src/test/kotlin/org/neo4j/graphql/utils/GraphQLSchemaTestSuite.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/utils/GraphQLSchemaTestSuite.kt
@@ -29,10 +29,9 @@ class GraphQLSchemaTestSuite(fileName: String) : AsciiDocTestSuite(
 
     override fun testFactory(title: String, globalBlocks: Map<String, ParsedBlock>, codeBlocks: Map<String, ParsedBlock>, ignore: Boolean): List<DynamicNode> {
         val targetSchemaBlock = codeBlocks[GRAPHQL_MARKER]
-        val compareSchemaTest = DynamicTest.dynamicTest("compare schema", targetSchemaBlock?.uri, {
+        val compareSchemaTest = DynamicTest.dynamicTest("compare schema", targetSchemaBlock?.uri) {
             val configBlock = codeBlocks[SCHEMA_CONFIG_MARKER]
-            val config = MAPPER.readValue(configBlock?.code()
-                    ?: throw IllegalStateException("missing config $title"), SchemaConfig::class.java)
+            val config = configBlock?.code()?.let { MAPPER.readValue(it, SchemaConfig::class.java) } ?: SchemaConfig()
 
             val targetSchema = targetSchemaBlock?.code()
                     ?: throw IllegalStateException("missing graphql for $title")
@@ -72,7 +71,7 @@ class GraphQLSchemaTestSuite(fileName: String) : AsciiDocTestSuite(
 
                 }
             }
-        })
+        }
         return Collections.singletonList(compareSchemaTest)
     }
 

--- a/core/src/test/resources/tck-test-files/cypher/pagination.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/pagination.adoc
@@ -1,0 +1,489 @@
+:toc:
+
+= Cypher pagination tests
+
+Tests for queries including reserved arguments `skip` and `limit`.
+
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    title: String
+    actors: [Actor!] @relation(name: "ACTS_IN", direction: IN)
+}
+
+type Actor {
+    id: ID
+    name: String
+    movies: [Movie!] @relation(name: "ACTS_IN", direction: OUT)
+}
+
+input ActorOptions {
+  limit: Int = 10
+  skip: Int = 0
+}
+----
+
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE"
+}
+----
+
+== For query
+
+=== Skipping
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie(options: { skip: 1 }) {
+        title
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "movieSkip" : 1
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie SKIP $movieSkip
+----
+
+=== Limit
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie(options: { limit: 1 }) {
+        title
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "movieLimit" : 1
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie LIMIT $movieLimit
+----
+
+=== Skip + Limit
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie(options: { limit: 1, skip: 2  }) {
+        title
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "movieLimit" : 1,
+  "movieSkip" : 2
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie SKIP $movieSkip LIMIT $movieLimit
+----
+
+=== Skip + Limit as variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($skip: Int, $limit: Int) {
+    movie(options: { limit: $limit, skip: $skip }) {
+        title
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "skip": 0,
+    "limit": 0
+}
+----
+
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "limit" : 0,
+  "skip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie SKIP $skip LIMIT $limit
+----
+
+=== Skip + Limit with other variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($skip: Int, $limit: Int, $title: String) {
+    movie(options: { limit: $limit, skip: $skip }, title: $title) {
+        title
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "limit": 1,
+    "skip": 2,
+    "title": "some title"
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "limit" : 1,
+  "skip" : 2,
+  "title" : "some title"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+WHERE movie.title = $title
+RETURN movie {
+	.title
+} AS movie SKIP $skip LIMIT $limit
+----
+
+=== Default values
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    actor {
+        name
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorSkip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+== For projection
+
+=== Skipping
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    actor {
+        name
+        movies (options: { skip: 1 }) {
+          title
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorMoviesSkip" : 1,
+  "actorSkip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name,
+	movies: [(actor)-[:ACTS_IN]->(actorMovies:Movie) | actorMovies {
+		.title
+	}][$actorMoviesSkip..]
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+=== Limit
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    actor {
+        name
+        movies (options: { limit: 1 }) {
+          title
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorMoviesLimit" : 1,
+  "actorSkip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name,
+	movies: [(actor)-[:ACTS_IN]->(actorMovies:Movie) | actorMovies {
+		.title
+	}][0..$actorMoviesLimit]
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+=== Skip + Limit
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    actor {
+        name
+        movies (options: { limit: 1, skip: 2 }) {
+          title
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorMoviesLimit" : 1,
+  "actorMoviesSkip" : 2,
+  "actorSkip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name,
+	movies: [(actor)-[:ACTS_IN]->(actorMovies:Movie) | actorMovies {
+		.title
+	}][$actorMoviesSkip..($actorMoviesSkip + $actorMoviesLimit)]
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+=== Skip + Limit as variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($skip: Int, $limit: Int) {
+    actor {
+        name
+        movies (options: { limit: $limit, skip: $skip }) {
+          title
+        }
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "skip": 0,
+    "limit": 0
+}
+----
+
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorSkip" : 0,
+  "limit" : 0,
+  "skip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name,
+	movies: [(actor)-[:ACTS_IN]->(actorMovies:Movie) | actorMovies {
+		.title
+	}][$skip..($skip + $limit)]
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+=== Skip + Limit with other variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($skip: Int, $limit: Int, $title: String) {
+    actor {
+        name
+        movies (options: { limit: $limit, skip: $skip }, title: $title) {
+          title
+        }
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "limit": 1,
+    "skip": 2,
+    "title": "some title"
+}
+----
+
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "actorLimit" : 10,
+  "actorSkip" : 0,
+  "limit" : 1,
+  "skip" : 2,
+  "title" : "some title"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (actor:Actor)
+RETURN actor {
+	.name,
+	movies: [(actor)-[:ACTS_IN]->(actorMovies:Movie) WHERE actorMovies.title = $title | actorMovies {
+		.title
+	}][$skip..($skip + $limit)]
+} AS actor SKIP $actorSkip LIMIT $actorLimit
+----
+
+=== Default values
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie {
+        title
+        actors {
+            name
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "movieActorsLimit" : 10,
+  "movieActorsSkip" : 0
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title,
+	actors: [(movie)<-[:ACTS_IN]-(movieActors:Actor) | movieActors {
+		.name
+	}][$movieActorsSkip..($movieActorsSkip + $movieActorsLimit)]
+} AS movie
+----

--- a/core/src/test/resources/tck-test-files/cypher/sort.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/sort.adoc
@@ -1,0 +1,328 @@
+:toc:
+
+= Cypher pagination tests
+
+Tests for queries including reserved arguments `skip` and `limit`.
+
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    title: String
+    genres: [Genre!] @relation(name: "HAS_GENRE", direction: OUT)
+}
+
+type Genre {
+    id: ID
+    name: String
+}
+
+input GenreOptions {
+  limit: Int
+  skip: Int
+  sort: [GenreSort!] = [{name: ASC}]
+}
+
+input GenreSort {
+    id: SortDirection
+    name: SortDirection
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE"
+}
+----
+
+== For query
+
+=== Simple Sort
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie(options: { sort: [{ id: DESC }] }) {
+        title
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie ORDER BY movie.id DESC
+----
+
+=== Multi Sort
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie(options: { sort: [{ id: DESC }, { title: ASC }] }) {
+        title
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title
+} AS movie ORDER BY movie.id DESC, movie.title ASC
+----
+
+=== Sort with skip limit & with other variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($title: String, $skip: Int, $limit: Int, $sort: [MovieSort!]) {
+    movie(
+        options: {
+            sort: $sort
+            skip: $skip
+            limit: $limit
+        }
+        title: $title
+    ) {
+        title
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "skip": 0,
+    "limit": 0,
+    "title" : "some title",
+    "sort": [{ "id": "DESC" }, { "title": "ASC" }]
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "limit" : 0,
+  "skip" : 0,
+  "title" : "some title"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+WHERE movie.title = $title
+RETURN movie {
+	.title
+} AS movie ORDER BY movie.id DESC, movie.title ASC SKIP $skip LIMIT $limit
+----
+
+=== Default values
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    genre {
+        name
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (genre:Genre)
+RETURN genre {
+	.name
+} AS genre ORDER BY genre.name ASC
+----
+
+== For projection
+
+=== Simple Sort
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie {
+        genres(options: { sort: [{ name: DESC }] }) {
+            name
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	genres: apoc.coll.sortMulti([(movie)-[:HAS_GENRE]->(movieGenres:Genre) | movieGenres {
+		.name
+	}], ['name'])
+} AS movie
+----
+
+=== Multi Sort
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie {
+        genres(options: { sort: [{ id: DESC }, { name: ASC }] }) {
+            name
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	genres: apoc.coll.sortMulti([(movie)-[:HAS_GENRE]->(movieGenres:Genre) | movieGenres {
+		.name
+	}], ['id', '^name'])
+} AS movie
+----
+
+=== Sort with skip limit & with other variables
+
+.GraphQL-Query
+[source,graphql]
+----
+query($name: String, $skip: Int, $limit: Int, $sort: [GenreSort!]) {
+    movie {
+        genres(
+            options: {
+                sort: $sort
+                skip: $skip
+                limit: $limit
+            }
+            name: $name
+        ) {
+            name
+        }
+        title
+    }
+}
+----
+
+.GraphQL params input
+[source,json,request=true]
+----
+{
+    "skip": 1,
+    "limit": 2,
+    "name" : "some name",
+    "sort": [{ "id": "DESC" }, { "name": "ASC" }]
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "limit" : 2,
+  "name" : "some name",
+  "skip" : 1
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	genres: apoc.coll.sortMulti([(movie)-[:HAS_GENRE]->(movieGenres:Genre) WHERE movieGenres.name = $name | movieGenres {
+		.name
+	}], ['id', '^name'])[$skip..($skip + $limit)],
+	.title
+} AS movie
+----
+
+=== Default values
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+    movie {
+        title
+        genres {
+            name
+        }
+    }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{ }
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movie:Movie)
+RETURN movie {
+	.title,
+	genres: apoc.coll.sortMulti([(movie)-[:HAS_GENRE]->(movieGenres:Genre) | movieGenres {
+		.name
+	}], ['^name'])
+} AS movie
+----

--- a/core/src/test/resources/tck-test-files/schema/relationship.adoc
+++ b/core/src/test/resources/tck-test-files/schema/relationship.adoc
@@ -1,0 +1,337 @@
+:toc:
+
+= Schema Relationship
+
+Tests that the provided typeDefs return the correct schema (with relationships).
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Actor {
+    name: String
+}
+
+type Movie {
+    id: ID
+    actors: [Actor]! @relation(name: "ACTED_IN", direction: IN)
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE"
+}
+----
+
+== Output
+
+.Augmented Schema
+[source,graphql]
+----
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Actor {
+  name: String
+}
+
+type Movie {
+  actors(filter: _ActorFilter, options: ActorOptions): [Actor]! @relation(direction : IN, from : "from", name : "ACTED_IN", to : "to")
+  id: ID
+}
+
+type Mutation {
+  createActor(name: String): Actor!
+  createMovie(id: ID): Movie!
+  "Deletes Movie and returns the type itself"
+  deleteMovie(id: ID): Movie
+}
+
+type Query {
+  actor(filter: _ActorFilter, name: String, options: ActorOptions): [Actor!]!
+  movie(filter: _MovieFilter, id: ID, options: MovieOptions): [Movie!]!
+}
+
+type _Neo4jDate {
+  day: Int
+  formatted: String
+  month: Int
+  year: Int
+}
+
+type _Neo4jDateTime {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+  year: Int
+}
+
+type _Neo4jLocalDateTime {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  year: Int
+}
+
+type _Neo4jLocalTime {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+}
+
+type _Neo4jPoint {
+  """
+   The coordinate reference systems (CRS)
+   -------------------------------------
+   posible values:
+   * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+     * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+     * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+   * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+     * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+     * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+   * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+   * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  """
+  crs: String
+  " The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)"
+  height: Float
+  """
+   The second element of the Coordinate for geographic CRS, degrees North of the equator
+   Range -90.0 to 90.0
+  """
+  latitude: Float
+  """
+   The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+   Range -180.0 to 180.0
+  """
+  longitude: Float
+  """
+   The internal Neo4j ID for the CRS
+   One of:
+   * `4326`: represents CRS `wgs-84`
+   * `4979`: represents CRS `wgs-84-3d`
+   * `7203`: represents CRS `cartesian`
+   * `9157`: represents CRS `cartesian-3d`
+  """
+  srid: Int
+  " The first element of the Coordinate"
+  x: Float
+  " The second element of the Coordinate"
+  y: Float
+  " The third element of the Coordinate"
+  z: Float
+}
+
+type _Neo4jTime {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+}
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+enum SortDirection {
+  "Sort by field values in ascending order."
+  ASC
+  "Sort by field values in descending order."
+  DESC
+}
+
+scalar DynamicProperties
+
+input ActorOptions {
+  "Defines the maximum amount of records returned"
+  limit: Int
+  "Defines the amount of records to be skipped"
+  skip: Int
+  "Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array."
+  sort: [ActorSort!]
+}
+
+"Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object."
+input ActorSort {
+  name: SortDirection
+}
+
+input MovieOptions {
+  "Defines the maximum amount of records returned"
+  limit: Int
+  "Defines the amount of records to be skipped"
+  skip: Int
+  "Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array."
+  sort: [MovieSort!]
+}
+
+"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object."
+input MovieSort {
+  id: SortDirection
+}
+
+input _ActorFilter {
+  AND: [_ActorFilter!]
+  NOT: [_ActorFilter!]
+  OR: [_ActorFilter!]
+  name: String
+  name_contains: String
+  name_ends_with: String
+  name_gt: String
+  name_gte: String
+  name_in: [String]
+  name_lt: String
+  name_lte: String
+  name_matches: String
+  name_not: String
+  name_not_contains: String
+  name_not_ends_with: String
+  name_not_in: [String]
+  name_not_starts_with: String
+  name_starts_with: String
+}
+
+input _ActorInput {
+  name: String
+}
+
+input _MovieFilter {
+  AND: [_MovieFilter!]
+  NOT: [_MovieFilter!]
+  OR: [_MovieFilter!]
+  "Filters only those `Movie` for which all `actors`-relationship matches this filter. If `null` is passed to this field, only those `Movie` will be filtered which has no `actors`-relations"
+  actors: _ActorFilter
+  "Filters only those `Movie` for which all `actors`-relationships matches this filter"
+  actors_every: _ActorFilter
+  "Filters only those `Movie` for which none of the `actors`-relationships matches this filter"
+  actors_none: _ActorFilter
+  "Filters only those `Movie` for which all `actors`-relationship does not match this filter. If `null` is passed to this field, only those `Movie` will be filtered which has any `actors`-relation"
+  actors_not: _ActorFilter
+  "Filters only those `Movie` for which exactly one `actors`-relationship matches this filter"
+  actors_single: _ActorFilter
+  "Filters only those `Movie` for which at least one `actors`-relationship matches this filter"
+  actors_some: _ActorFilter
+  id: ID
+  id_contains: ID
+  id_ends_with: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_lt: ID
+  id_lte: ID
+  id_matches: ID
+  id_not: ID
+  id_not_contains: ID
+  id_not_ends_with: ID
+  id_not_in: [ID]
+  id_not_starts_with: ID
+  id_starts_with: ID
+}
+
+input _MovieInput {
+  id: ID
+}
+
+input _Neo4jDateInput {
+  day: Int
+  formatted: String
+  month: Int
+  year: Int
+}
+
+input _Neo4jDateTimeInput {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+  year: Int
+}
+
+input _Neo4jLocalDateTimeInput {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  year: Int
+}
+
+input _Neo4jLocalTimeInput {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+}
+
+input _Neo4jPointInput {
+  crs: String
+  height: Float
+  latitude: Float
+  longitude: Float
+  srid: Int
+  x: Float
+  y: Float
+  z: Float
+}
+
+input _Neo4jTimeInput {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+}
+
+directive @relation(name:String, direction: RelationDirection = OUT, from: String = "from", to: String = "to") on FIELD_DEFINITION | OBJECT
+directive @cypher(statement:String, passThrough: Boolean = false) on FIELD_DEFINITION
+directive @property(name:String) on FIELD_DEFINITION
+directive @dynamic(prefix:String = "properties.") on FIELD_DEFINITION
+
+----

--- a/core/src/test/resources/tck-test-files/schema/simple.adoc
+++ b/core/src/test/resources/tck-test-files/schema/simple.adoc
@@ -1,0 +1,306 @@
+:toc:
+
+= Schema Simple
+
+Tests that the provided typeDefs return the correct schema.
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    actorCount: Int
+    averageRating: Float
+    isActive: Boolean
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE"
+}
+----
+
+== Output
+
+.Augmented Schema
+[source,graphql]
+----
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Movie {
+  actorCount: Int
+  averageRating: Float
+  id: ID
+  isActive: Boolean
+}
+
+type Mutation {
+  createMovie(actorCount: Int, averageRating: Float, id: ID, isActive: Boolean): Movie!
+  "Deletes Movie and returns the type itself"
+  deleteMovie(id: ID): Movie
+  mergeMovie(actorCount: Int, averageRating: Float, id: ID, isActive: Boolean): Movie!
+  updateMovie(actorCount: Int, averageRating: Float, id: ID, isActive: Boolean): Movie
+}
+
+type Query {
+  movie(actorCount: Int, averageRating: Float, filter: _MovieFilter, id: ID, isActive: Boolean, options: MovieOptions): [Movie!]!
+}
+
+type _Neo4jDate {
+  day: Int
+  formatted: String
+  month: Int
+  year: Int
+}
+
+type _Neo4jDateTime {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+  year: Int
+}
+
+type _Neo4jLocalDateTime {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  year: Int
+}
+
+type _Neo4jLocalTime {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+}
+
+type _Neo4jPoint {
+  """
+   The coordinate reference systems (CRS)
+   -------------------------------------
+   posible values:
+   * `wgs-84`: A 2D geographic point in the WGS 84 CRS is specified in one of two ways:
+     * longitude and latitude (if these are specified, and the crs is not, then the crs is assumed to be WGS-84)
+     * x and y (in this case the crs must be specified, or will be assumed to be Cartesian)
+   * `wgs-84-3d`: A 3D geographic point in the WGS 84 CRS is specified one of in two ways:
+     * longitude, latitude and either height or z (if these are specified, and the crs is not, then the crs is assumed to be WGS-84-3D)
+     * x, y and z (in this case the crs must be specified, or will be assumed to be Cartesian-3D)
+   * `cartesian`: A 2D point in the Cartesian CRS is specified with a map containing x and y coordinate values
+   * `cartesian-3d`: A 3D point in the Cartesian CRS is specified with a map containing x, y and z coordinate values
+  """
+  crs: String
+  " The third element of the Coordinate for geographic CRS, meters above the ellipsoid defined by the datum (WGS-84)"
+  height: Float
+  """
+   The second element of the Coordinate for geographic CRS, degrees North of the equator
+   Range -90.0 to 90.0
+  """
+  latitude: Float
+  """
+   The first element of the Coordinate for geographic CRS, degrees East of the prime meridian
+   Range -180.0 to 180.0
+  """
+  longitude: Float
+  """
+   The internal Neo4j ID for the CRS
+   One of:
+   * `4326`: represents CRS `wgs-84`
+   * `4979`: represents CRS `wgs-84-3d`
+   * `7203`: represents CRS `cartesian`
+   * `9157`: represents CRS `cartesian-3d`
+  """
+  srid: Int
+  " The first element of the Coordinate"
+  x: Float
+  " The second element of the Coordinate"
+  y: Float
+  " The third element of the Coordinate"
+  z: Float
+}
+
+type _Neo4jTime {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+}
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+enum SortDirection {
+  "Sort by field values in ascending order."
+  ASC
+  "Sort by field values in descending order."
+  DESC
+}
+
+scalar DynamicProperties
+
+input MovieOptions {
+  "Defines the maximum amount of records returned"
+  limit: Int
+  "Defines the amount of records to be skipped"
+  skip: Int
+  "Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array."
+  sort: [MovieSort!]
+}
+
+"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object."
+input MovieSort {
+  actorCount: SortDirection
+  averageRating: SortDirection
+  id: SortDirection
+  isActive: SortDirection
+}
+
+input _MovieFilter {
+  AND: [_MovieFilter!]
+  NOT: [_MovieFilter!]
+  OR: [_MovieFilter!]
+  actorCount: Int
+  actorCount_gt: Int
+  actorCount_gte: Int
+  actorCount_in: [Int]
+  actorCount_lt: Int
+  actorCount_lte: Int
+  actorCount_not: Int
+  actorCount_not_in: [Int]
+  averageRating: Float
+  averageRating_gt: Float
+  averageRating_gte: Float
+  averageRating_in: [Float]
+  averageRating_lt: Float
+  averageRating_lte: Float
+  averageRating_not: Float
+  averageRating_not_in: [Float]
+  id: ID
+  id_contains: ID
+  id_ends_with: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_lt: ID
+  id_lte: ID
+  id_matches: ID
+  id_not: ID
+  id_not_contains: ID
+  id_not_ends_with: ID
+  id_not_in: [ID]
+  id_not_starts_with: ID
+  id_starts_with: ID
+  isActive: Boolean
+  isActive_not: Boolean
+}
+
+input _MovieInput {
+  actorCount: Int
+  averageRating: Float
+  id: ID
+  isActive: Boolean
+}
+
+input _Neo4jDateInput {
+  day: Int
+  formatted: String
+  month: Int
+  year: Int
+}
+
+input _Neo4jDateTimeInput {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+  year: Int
+}
+
+input _Neo4jLocalDateTimeInput {
+  day: Int
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  month: Int
+  nanosecond: Int
+  second: Int
+  year: Int
+}
+
+input _Neo4jLocalTimeInput {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+}
+
+input _Neo4jPointInput {
+  crs: String
+  height: Float
+  latitude: Float
+  longitude: Float
+  srid: Int
+  x: Float
+  y: Float
+  z: Float
+}
+
+input _Neo4jTimeInput {
+  formatted: String
+  hour: Int
+  microsecond: Int
+  millisecond: Int
+  minute: Int
+  nanosecond: Int
+  second: Int
+  timezone: String
+}
+
+directive @relation(name:String, direction: RelationDirection = OUT, from: String = "from", to: String = "to") on FIELD_DEFINITION | OBJECT
+directive @cypher(statement:String) on FIELD_DEFINITION
+directive @property(name:String) on FIELD_DEFINITION
+directive @dynamic(prefix:String = "properties.") on FIELD_DEFINITION
+
+----

--- a/readme.adoc
+++ b/readme.adoc
@@ -25,6 +25,15 @@ NOTE: All the <<features,supported features>> are listed and explained below, mo
 
 For complex examples take a look at our link:examples/readme.adoc[example projects]
 
+
+== API compatibility to @neo4j/graphql
+
+Since the javascript pendant of this library (neo4j-graphql-js) has majored into a neo4j product, we want to migrate our augmented schema, to match as much as possible to the one of the https://github.com/neo4j/graphql-tracker-temp[`@neo4j/graphql`].
+Therefore, we created a https://github.com/neo4j-graphql/neo4j-graphql-java/issues?q=label%3AAPI-Alignment[list of issues to track progress].
+
+We will try to make the migration as smooth as possible. For this purpose we will support the old, and the new way of schema augmentation until the next major release.
+To already test the new features, you can enable them via link:core/src/main/kotlin/org/neo4j/graphql/SchemaConfig.kt[some setting in the `SchemaConfig`]
+
 == FAQ
 
 === How does this relate to the other neo4j graphql libraries?
@@ -46,7 +55,7 @@ If you wanted, you could combine `graphql-java` resolvers with this library to h
 
 Thanks a lot to the maintainers of `graphql-java` for the awesome library.
 
-NOTE: We also use `neo4j-opencypher-dsl` provided graciously by the spring-data-neo4j-rx project to generate parts of the cypher queries.
+NOTE: We also use `neo4j-opencypher-dsl` provided graciously by the spring-data-neo4j-rx project to generate our cypher queries.
 
 == Usage
 


### PR DESCRIPTION
This feature is part of migrating our API to the one generated by `@neo4j/graphql`.
Here we move the fields for paging and sorting into a options input type, which can be passed to queries and projected relational fields

resolves #196