### PR TITLE
Run integration tests through the GraphQL API

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -20,9 +20,7 @@ jobs:
           java-version: 11
           distribution: adopt
       - name: Run Maven build
-# TODO after fixing all integration tests
-#        run:  ./mvnw --no-transfer-progress -Dneo4j-graphql-java.integration-tests=true clean compile test
-        run:  ./mvnw --no-transfer-progress clean compile test
+        run:  ./mvnw --no-transfer-progress -Dneo4j-graphql-java.integration-tests=true -Dneo4j-graphql-java.generate-test-file-diff=false clean compile test
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/core/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/CypherTests.kt
@@ -1,5 +1,6 @@
 package org.neo4j.graphql
 
+import apoc.coll.Coll
 import apoc.cypher.CypherFunctions
 import org.junit.jupiter.api.*
 import org.neo4j.graphql.utils.CypherTestSuite
@@ -22,6 +23,8 @@ class CypherTests {
                 .newInProcessBuilder(Path.of("target/test-db"))
                 .withProcedure(apoc.cypher.Cypher::class.java)
                 .withFunction(CypherFunctions::class.java)
+                .withProcedure(Coll::class.java)
+                .withFunction(Coll::class.java)
                 .build()
         }
     }

--- a/core/src/test/resources/filter-tests.adoc
+++ b/core/src/test/resources/filter-tests.adoc
@@ -3206,7 +3206,7 @@ RETURN p {
 .GraphQL-Query
 [source,graphql]
 ----
-{ p: company { employees(filter: { OR: [{ name: "Jane" },{name:"Joe"}]}) { name }}}
+{ p: company { employees(filter: { OR: [{ name: "Jane" },{name:"Joe"}]}, orderBy: name_desc) { name }}}
 ----
 
 .GraphQL-Response
@@ -3239,10 +3239,10 @@ RETURN p {
 ----
 MATCH (p:Company)
 RETURN p {
-	employees: [(p)<-[:WORKS_AT]-(pEmployees:Person) WHERE (pEmployees.name = $filterPEmployeesOr1Name
-	OR pEmployees.name = $filterPEmployeesOr2Name) | pEmployees {
+	employees: apoc.coll.sortMulti([(p)<-[:WORKS_AT]-(pEmployees:Person) WHERE (pEmployees.name = $filterPEmployeesOr1Name
+		OR pEmployees.name = $filterPEmployeesOr2Name) | pEmployees {
 		.name
-	}]
+	}], ['name'])
 } AS p
 ----
 

--- a/core/src/test/resources/issues/gh-112.adoc
+++ b/core/src/test/resources/issues/gh-112.adoc
@@ -31,7 +31,7 @@ CREATE
 .GraphQL-Query
 [source,graphql]
 ----
-query {
+query user( $uuid: ID ){
   user(uuid: $uuid) {
     uuid
     name

--- a/core/src/test/resources/issues/gh-147.adoc
+++ b/core/src/test/resources/issues/gh-147.adoc
@@ -60,7 +60,9 @@ query {
     person(name: "Kevin Bacon") {
         born
         ... on Actor {
+            __typename
             namedColleagues(name: "Meg") {
+                __typename
                 ... name
             }
         }
@@ -75,11 +77,13 @@ fragment name on Actor { name }
 ----
 {
   "person" : [ {
+    "born" : 1958,
+    "__typename" : "Actor",
     "namedColleagues" : [ {
+      "__typename" : "Actor",
       "name" : "Meg Ryan"
     } ],
-    "score" : 7,
-    "born" : 1958
+    "score" : 7
   } ]
 }
 ----
@@ -90,7 +94,9 @@ fragment name on Actor { name }
 {
   "personName" : "Kevin Bacon",
   "personNamedColleaguesName" : "Meg",
-  "personScoreValue" : 7
+  "personNamedColleaguesValidTypes" : [ "Actor" ],
+  "personScoreValue" : 7,
+  "personValidTypes" : [ "Actor" ]
 }
 ----
 
@@ -101,10 +107,12 @@ MATCH (person:Person)
 WHERE person.name = $personName
 RETURN person {
 	.born,
+	__typename: head([label IN labels(person) WHERE label IN $personValidTypes]),
 	namedColleagues: [personNamedColleagues IN apoc.cypher.runFirstColumnMany('WITH $this AS this, $name AS name WITH $this AS this MATCH (this)-[:ACTED_IN]->()<-[:ACTED_IN]-(other) WHERE other.name CONTAINS $name RETURN other',  {
 		this: person,
 		name: $personNamedColleaguesName
 	}) | personNamedColleagues {
+		__typename: head([label IN labels(personNamedColleagues) WHERE label IN $personNamedColleaguesValidTypes]),
 		.name
 	}],
 	score: apoc.cypher.runFirstColumnSingle('WITH $this AS this, $value AS value RETURN $value',  {


### PR DESCRIPTION
With this change, integration tests will route calls directly through the GraphQL API and not just to the translator. Thus we can find potential errors in the return values faster.