### PR TITLE
Augment filter argument for nested fields

### DIFF
--- a/core/src/test/resources/augmentation-tests.adoc
+++ b/core/src/test/resources/augmentation-tests.adoc
@@ -396,7 +396,7 @@ schema {
 }
 
 interface HasMovies {
-  movies(first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
+  movies(filter: _MovieFilter, first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
 }
 
 type Knows0 @relation(direction : OUT, from : "source", name : "KNOWS", to : "knows") {
@@ -454,7 +454,7 @@ type Person4 {
 
 type Person5 implements HasMovies {
   id: ID!
-  movies(first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie] @relation(direction : OUT, from : "from", name : "LIKES", to : "to")
+  movies(filter: _MovieFilter, first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie] @relation(direction : OUT, from : "from", name : "LIKES", to : "to")
 }
 
 type Publisher {

--- a/core/src/test/resources/issues/gh-170.adoc
+++ b/core/src/test/resources/issues/gh-170.adoc
@@ -42,7 +42,7 @@ CREATE
 [source,graphql]
 ----
 query {
-    r: rated( rating_gte : 3) {
+    r: rated( filter: {rating_gte : 3}) {
       rating
       movie {
         title
@@ -55,7 +55,7 @@ query {
 [source,json]
 ----
 {
-  "rRatingGte" : 3
+  "filterRRatingGte" : 3
 }
 ----
 
@@ -74,7 +74,7 @@ query {
 [source,cypher]
 ----
 MATCH ()-[r:RATED]->()
-WHERE r.rating >= $rRatingGte
+WHERE r.rating >= $filterRRatingGte
 RETURN r {
 	.rating,
 	movie: head([()-[r]->(movie:Movie) | movie {


### PR DESCRIPTION
If the field of GraphQL Type maps to an *..n relation (a list) and there is currently no `filter`-argument defined, we now generate it in the augmented schema.
The logic for handling these nested filters is already implementd, so no further code-adjustments are required.

resolves #129