### PR TITLE
Add datetime comparisons for filtering (#93)

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -44,6 +44,8 @@ fun GraphQLType.requiredName(): String = requireNotNull(name()) { "name is requi
 fun GraphQLType.isList() = this is GraphQLList || (this is GraphQLNonNull && this.wrappedType is GraphQLList)
 fun GraphQLType.isNeo4jType() = this.innerName().startsWith("_Neo4j")
 
+fun TypeDefinition<*>.isNeo4jDateType() = this.name.startsWith("_Neo4j") && (this.name.contains("Date") || this.name.contains("Time"))
+
 fun GraphQLType.isNeo4jSpatialType() = this.innerName().startsWith("_Neo4jPoint")
 fun TypeDefinition<*>.isNeo4jSpatialType() = this.name.startsWith("_Neo4jPoint")
 

--- a/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
@@ -115,6 +115,7 @@ enum class FieldOperator(
                     type.name == TypeBoolean.name -> listOf(EQ, NEQ)
                     type.name == NEO4j_POINT_DISTANCE_FILTER -> listOf(EQ, LT, LTE, GT, GTE)
                     type.isNeo4jSpatialType() -> listOf(EQ, NEQ)
+                    type.isNeo4jDateType() -> listOf(EQ, NEQ, IN, NIN, LT, LTE, GT, GTE)
                     isNeo4jType -> listOf(EQ, NEQ, IN, NIN)
                     type is ImplementingTypeDefinition<*> -> throw IllegalArgumentException("This operators are not for relations, use the RelationOperator instead")
                     type is EnumTypeDefinition -> listOf(EQ, NEQ, IN, NIN)

--- a/core/src/test/resources/augmentation-tests.adoc
+++ b/core/src/test/resources/augmentation-tests.adoc
@@ -923,7 +923,11 @@ input _Person0Filter {
   NOT: [_Person0Filter!]
   OR: [_Person0Filter!]
   born: _Neo4jTimeInput
+  born_gt: _Neo4jTimeInput
+  born_gte: _Neo4jTimeInput
   born_in: [_Neo4jTimeInput]
+  born_lt: _Neo4jTimeInput
+  born_lte: _Neo4jTimeInput
   born_not: _Neo4jTimeInput
   born_not_in: [_Neo4jTimeInput]
   location: _Neo4jPointInput
@@ -955,7 +959,11 @@ input _Person1Filter {
   NOT: [_Person1Filter!]
   OR: [_Person1Filter!]
   born: _Neo4jDateInput
+  born_gt: _Neo4jDateInput
+  born_gte: _Neo4jDateInput
   born_in: [_Neo4jDateInput]
+  born_lt: _Neo4jDateInput
+  born_lte: _Neo4jDateInput
   born_not: _Neo4jDateInput
   born_not_in: [_Neo4jDateInput]
   name: String
@@ -993,7 +1001,11 @@ input _Person2Filter {
   age_not: Int
   age_not_in: [Int]
   born: _Neo4jDateTimeInput
+  born_gt: _Neo4jDateTimeInput
+  born_gte: _Neo4jDateTimeInput
   born_in: [_Neo4jDateTimeInput]
+  born_lt: _Neo4jDateTimeInput
+  born_lte: _Neo4jDateTimeInput
   born_not: _Neo4jDateTimeInput
   born_not_in: [_Neo4jDateTimeInput]
   name: String
@@ -1024,7 +1036,11 @@ input _Person3Filter {
   NOT: [_Person3Filter!]
   OR: [_Person3Filter!]
   born: _Neo4jLocalTimeInput
+  born_gt: _Neo4jLocalTimeInput
+  born_gte: _Neo4jLocalTimeInput
   born_in: [_Neo4jLocalTimeInput]
+  born_lt: _Neo4jLocalTimeInput
+  born_lte: _Neo4jLocalTimeInput
   born_not: _Neo4jLocalTimeInput
   born_not_in: [_Neo4jLocalTimeInput]
   name: String
@@ -1054,7 +1070,11 @@ input _Person4Filter {
   NOT: [_Person4Filter!]
   OR: [_Person4Filter!]
   born: _Neo4jLocalDateTimeInput
+  born_gt: _Neo4jLocalDateTimeInput
+  born_gte: _Neo4jLocalDateTimeInput
   born_in: [_Neo4jLocalDateTimeInput]
+  born_lt: _Neo4jLocalDateTimeInput
+  born_lte: _Neo4jLocalDateTimeInput
   born_not: _Neo4jLocalDateTimeInput
   born_not_in: [_Neo4jLocalDateTimeInput]
   id: ID


### PR DESCRIPTION
Issue #93 (plus others like #223) requires the ability to perform filtering with simple date comparisons.

This patch determines whether a type is a Neo4j Date/Time and augments it with filters for GT/GTE/LT/LTE (over and above the existing augmentation for a Neo4j type).