### PR TITLE
Use scalars for temporal types

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -43,11 +43,12 @@ fun GraphQLType.requiredName(): String = requireNotNull(name()) { "name is requi
 
 fun GraphQLType.isList() = this is GraphQLList || (this is GraphQLNonNull && this.wrappedType is GraphQLList)
 fun GraphQLType.isNeo4jType() = this.innerName().startsWith("_Neo4j")
+fun GraphQLType.isNeo4jTemporalType() = NEO4j_TEMPORAL_TYPES.contains(this.innerName())
 
-fun GraphQLType.isNeo4jSpatialType() = this.innerName().startsWith("_Neo4jPoint")
 fun TypeDefinition<*>.isNeo4jSpatialType() = this.name.startsWith("_Neo4jPoint")
 
 fun GraphQLFieldDefinition.isNeo4jType(): Boolean = this.type.isNeo4jType()
+fun GraphQLFieldDefinition.isNeo4jTemporalType(): Boolean = this.type.isNeo4jTemporalType()
 
 fun GraphQLFieldDefinition.isRelationship() = !type.isNeo4jType() && this.type.inner().let { it is GraphQLFieldsContainer }
 
@@ -184,7 +185,7 @@ fun Value<*>.toJavaValue(): Any? = when (this) {
 
 fun GraphQLFieldDefinition.isID() = this.type.inner() == Scalars.GraphQLID
 fun GraphQLFieldDefinition.isNativeId() = this.name == ProjectionBase.NATIVE_ID
-fun GraphQLFieldDefinition.isIgnored() =  getDirective(DirectiveConstants.IGNORE) != null
+fun GraphQLFieldDefinition.isIgnored() = getDirective(DirectiveConstants.IGNORE) != null
 fun FieldDefinition.isIgnored(): Boolean = hasDirective(DirectiveConstants.IGNORE)
 
 fun GraphQLFieldsContainer.getIdField() = this.getRelevantFieldDefinitions().find { it.isID() }

--- a/core/src/main/kotlin/org/neo4j/graphql/Neo4jTypes.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Neo4jTypes.kt
@@ -18,6 +18,16 @@ data class TypeDefinition(
         val inputDefinition: String = typeDefinition + "Input"
 )
 
+class Neo4jTemporalConverter(name: String) : Neo4jSimpleConverter(name) {
+    override fun projectField(variable: SymbolicName, field: Field, name: String): Any {
+        return Cypher.call("toString").withArgs(variable.property(field.name)).asFunction()
+    }
+
+    override fun createCondition(property: Property, parameter: Parameter<Any>, conditionCreator: (Expression, Expression) -> Condition): Condition {
+        return conditionCreator(property, toExpression(parameter))
+    }
+}
+
 class Neo4jTimeConverter(name: String) : Neo4jConverter(name) {
 
     override fun createCondition(
@@ -63,14 +73,22 @@ class Neo4jPointConverter(name: String) : Neo4jConverter(name) {
 }
 
 open class Neo4jConverter(
-        val name: String,
+        name: String,
         val prefixedName: String = "_Neo4j$name",
         val typeDefinition: TypeDefinition = TypeDefinition(name, prefixedName)
-) {
+) : Neo4jSimpleConverter(name) {
+}
 
+open class Neo4jSimpleConverter(val name: String) {
     protected fun toExpression(parameter: Expression): Expression {
         return Cypher.call(name.toLowerCase()).withArgs(parameter).asFunction()
     }
+
+    open fun createCondition(
+            property: Property,
+            parameter: Parameter<Any>,
+            conditionCreator: (Expression, Expression) -> Condition
+    ): Condition = conditionCreator(property, parameter)
 
     open fun createCondition(
             objectField: ObjectField,
@@ -78,8 +96,7 @@ open class Neo4jConverter(
             parameter: Parameter<Any>,
             conditionCreator: (Expression, Expression) -> Condition,
             propertyContainer: PropertyContainer
-    ): Condition = conditionCreator(propertyContainer.property(field.name, objectField.name), parameter)
-
+    ): Condition = createCondition(propertyContainer.property(field.name, objectField.name), parameter, conditionCreator)
 
     open fun projectField(variable: SymbolicName, field: Field, name: String): Any = variable.property(field.name, name)
 
@@ -89,10 +106,10 @@ open class Neo4jConverter(
     }
 }
 
-fun getNeo4jTypeConverter(field: GraphQLFieldDefinition): Neo4jConverter = getNeo4jTypeConverter(field.type.innerName())
+fun getNeo4jTypeConverter(field: GraphQLFieldDefinition): Neo4jSimpleConverter = getNeo4jTypeConverter(field.type.innerName())
 
-fun getNeo4jTypeConverter(name: String): Neo4jConverter =
-        neo4jConverter[name] ?: throw RuntimeException("Type $name not found")
+private fun getNeo4jTypeConverter(name: String): Neo4jSimpleConverter =
+        neo4jConverter[name] ?: neo4jScalarConverter[name] ?: throw RuntimeException("Type $name not found")
 
 private val neo4jConverter = listOf(
         Neo4jTimeConverter("LocalTime"),
@@ -104,5 +121,17 @@ private val neo4jConverter = listOf(
 )
     .map { it.prefixedName to it }
     .toMap()
+
+private val neo4jScalarConverter = listOf(
+        Neo4jTemporalConverter("LocalTime"),
+        Neo4jTemporalConverter("Date"),
+        Neo4jTemporalConverter("DateTime"),
+        Neo4jTemporalConverter("Time"),
+        Neo4jTemporalConverter("LocalDateTime")
+)
+    .map { it.name to it }
+    .toMap()
+
+val NEO4j_TEMPORAL_TYPES = neo4jScalarConverter.keys
 
 val neo4jTypeDefinitions = neo4jConverter.values.map { it.typeDefinition }

--- a/core/src/main/kotlin/org/neo4j/graphql/SchemaConfig.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/SchemaConfig.kt
@@ -24,6 +24,11 @@ data class SchemaConfig @JvmOverloads constructor(
          * additionally the separated filter arguments will no longer be generated.
          */
         val useWhereFilter: Boolean = false,
+
+        /**
+         * if enabled the `Date`, `Time`, `LocalTime`, `DateTime` and `LocalDateTime` are used as scalars
+         */
+        val useTemporalScalars: Boolean = false,
 ) {
     data class CRUDConfig(val enabled: Boolean = true, val exclude: List<String> = emptyList())
 

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcherForContainer.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcherForContainer.kt
@@ -35,7 +35,7 @@ abstract class BaseDataFetcherForContainer(schemaConfig: SchemaConfig) : BaseDat
                 val dynamicPrefix = field.dynamicPrefix()
                 propertyFields[field.name] = when {
                     dynamicPrefix != null -> dynamicPrefixCallback(field, dynamicPrefix)
-                    field.isNeo4jType() -> neo4jTypeCallback(field)
+                    field.isNeo4jType() || (schemaConfig.useTemporalScalars && field.isNeo4jTemporalType()) -> neo4jTypeCallback(field)
                     else -> defaultCallback(field)
                 }
             }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/filter/OptimizedFilterHandler.kt
@@ -69,7 +69,7 @@ class OptimizedFilterHandler(val type: GraphQLFieldsContainer, schemaConfig: Sch
      * @param value the value passed to the graphQL field
      * @param parentPassThroughWiths all the nodes, required to be passed through via WITH
      */
-    class NestingLevelHandler(
+    inner class NestingLevelHandler(
             private val parsedQuery: ParsedQuery,
             private val useDistinct: Boolean,
             private val current: PropertyContainer,
@@ -113,7 +113,7 @@ class OptimizedFilterHandler(val type: GraphQLFieldsContainer, schemaConfig: Sch
             }
 
             // WHERE MATCH all predicates for current
-            val condition = parsedQuery.getFieldConditions(current, variablePrefix, "")
+            val condition = parsedQuery.getFieldConditions(current, variablePrefix, "", schemaConfig)
             val matchQueryWithWhere = matchQueryWithoutWhere.where(condition)
 
             return if (additionalConditions != null) {

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
@@ -139,7 +139,7 @@ open class ProjectionBase(
             type: GraphQLFieldsContainer,
             variables: Map<String, Any>
     ): Condition {
-        var result = parsedQuery.getFieldConditions(propertyContainer, variablePrefix, variableSuffix)
+        var result = parsedQuery.getFieldConditions(propertyContainer, variablePrefix, variableSuffix, schemaConfig)
 
         for (predicate in parsedQuery.relationPredicates) {
             val objectField = predicate.queryField
@@ -269,6 +269,9 @@ open class ProjectionBase(
             }
 
         } else when {
+            schemaConfig.useTemporalScalars && fieldDefinition.isNeo4jTemporalType() -> {
+                projections += getNeo4jTypeConverter(fieldDefinition).projectField(variable, field, "")
+            }
             isObjectField -> {
                 if (fieldDefinition.isNeo4jType()) {
                     if (propertiesToSkipDeepProjection.contains(fieldDefinition.name)) {

--- a/core/src/main/kotlin/org/neo4j/graphql/parser/QueryParser.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/parser/QueryParser.kt
@@ -20,9 +20,9 @@ class ParsedQuery(
         val and: List<Value<*>>? = null
 ) {
 
-    fun getFieldConditions(propertyContainer: PropertyContainer, variablePrefix: String, variableSuffix: String): Condition =
+    fun getFieldConditions(propertyContainer: PropertyContainer, variablePrefix: String, variableSuffix: String, schemaConfig: SchemaConfig): Condition =
             fieldPredicates
-                .flatMap { it.createCondition(propertyContainer, variablePrefix, variableSuffix) }
+                .flatMap { it.createCondition(propertyContainer, variablePrefix, variableSuffix, schemaConfig) }
                 .reduceOrNull { result, condition -> result.and(condition) }
                     ?: Conditions.noCondition()
 }
@@ -43,13 +43,14 @@ class FieldPredicate(
         index: Int
 ) : Predicate<FieldOperator>(op, queryField, normalizeName(fieldDefinition.name, op.suffix.toCamelCase()), index) {
 
-    fun createCondition(propertyContainer: PropertyContainer, variablePrefix: String, variableSuffix: String) =
+    fun createCondition(propertyContainer: PropertyContainer, variablePrefix: String, variableSuffix: String, schemaConfig: SchemaConfig) =
             op.resolveCondition(
                     variablePrefix,
                     normalizedName,
                     propertyContainer,
                     fieldDefinition,
                     queryField.value,
+                    schemaConfig,
                     variableSuffix
             )
 

--- a/core/src/main/resources/neo4j_types.graphql
+++ b/core/src/main/resources/neo4j_types.graphql
@@ -110,3 +110,9 @@ type _Neo4jPoint{
   # * `9157`: represents CRS `cartesian-3d`
   srid: Int
 }
+
+scalar Date
+scalar Time
+scalar LocalTime
+scalar DateTime
+scalar LocalDateTime

--- a/core/src/test/resources/tck-test-files/cypher/types/datetime.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/types/datetime.adoc
@@ -1,0 +1,231 @@
+:toc:
+
+= Schema DateTime
+
+Tests DateTime operations.
+
+== Schema
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    datetime: DateTime
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE",
+  "useWhereFilter": true,
+  "pluralizeFields": true,
+  "useTemporalScalars": true
+}
+----
+
+== Test Data
+
+[source,cypher,test-data=true]
+----
+CREATE
+    (:Movie{ id: 'm1', datetime: datetime('1970-01-01T00:00:00.000Z') }),
+    (:Movie{ id: 'm2', datetime: datetime('1980-01-01T00:00:00.001Z') }),
+    (:Movie{ id: 'm3', datetime: datetime('1980-01-02T00:00:00.002Z') }),
+    (:Movie{ id: 'm4', datetime: datetime('2000-01-02T00:00:00.002Z') })
+----
+
+== Tests
+
+=== Simple Read
+
+.GraphQL-Query
+[source,graphql]
+----
+query {
+    movies(where: { datetime: "1970-01-01T00:00:00.000Z" }) {
+        id
+        datetime
+    }
+}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "movies" : [ {
+    "id" : "m1",
+    "datetime" : "1970-01-01T00:00:00Z"
+  } ]
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "whereMoviesDatetime" : "1970-01-01T00:00:00.000Z"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movies:Movie)
+WHERE movies.datetime = datetime($whereMoviesDatetime)
+RETURN movies {
+	.id,
+	datetime: toString(movies.datetime)
+} AS movies
+----
+
+=== Complex Read
+
+.GraphQL-Query
+[source,graphql]
+----
+query {
+    movies(
+        where: { AND: [{ datetime_gt: "1970-01-01T00:00:00.000Z" }, { datetime_lt: "2000-01-02T00:00:00.002Z" }]}
+        options: { sort: [ { datetime: DESC} ] }
+    ) {
+        id
+        datetime
+    }
+}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "movies" : [ {
+    "id" : "m3",
+    "datetime" : "1980-01-02T00:00:00.002Z"
+  }, {
+    "id" : "m2",
+    "datetime" : "1980-01-01T00:00:00.001Z"
+  } ]
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "whereMoviesAnd1DatetimeGt" : "1970-01-01T00:00:00.000Z",
+  "whereMoviesAnd2DatetimeLt" : "2000-01-02T00:00:00.002Z"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (movies:Movie)
+WHERE (movies.datetime > datetime($whereMoviesAnd1DatetimeGt)
+	AND movies.datetime < datetime($whereMoviesAnd2DatetimeLt))
+RETURN movies {
+	.id,
+	datetime: toString(movies.datetime)
+} AS movies ORDER BY movies.datetime DESC
+----
+
+=== Simple Create
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+    createMovie(datetime: "1970-01-01T00:00:00.000Z", id: "m4") {
+        id
+        datetime
+    }
+}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "createMovie" : {
+    "id" : "m4",
+    "datetime" : "1970-01-01T00:00:00Z"
+  }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "createMovieDatetime" : "1970-01-01T00:00:00.000Z",
+  "createMovieId" : "m4"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+CREATE (createMovie:Movie  {
+	datetime: datetime($createMovieDatetime),
+	id: $createMovieId
+})
+WITH createMovie
+RETURN createMovie {
+	.id,
+	datetime: toString(createMovie.datetime)
+} AS createMovie
+----
+
+=== Simple Update
+
+.GraphQL-Query
+[source,graphql]
+----
+mutation {
+    updateMovie(id: "m1", datetime: "2000-01-01T00:00:00.000Z") {
+        id
+        datetime
+    }
+}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "updateMovie" : {
+    "id" : "m1",
+    "datetime" : "2000-01-01T00:00:00Z"
+  }
+}
+----
+
+.Expected Cypher params
+[source,json]
+----
+{
+  "updateMovieDatetime" : "2000-01-01T00:00:00.000Z",
+  "updateMovieId" : "m1"
+}
+----
+
+.Expected Cypher output
+[source,cypher]
+----
+MATCH (updateMovie:Movie  {
+	id: $updateMovieId
+})
+SET updateMovie +=  {
+	datetime: datetime($updateMovieDatetime)
+}
+WITH updateMovie
+RETURN updateMovie {
+	.id,
+	datetime: toString(updateMovie.datetime)
+} AS updateMovie
+----

--- a/core/src/test/resources/tck-test-files/schema/types/datetime.adoc
+++ b/core/src/test/resources/tck-test-files/schema/types/datetime.adoc
@@ -1,0 +1,119 @@
+:toc:
+
+= Schema DateTime
+
+Tests that the provided typeDefs return the correct schema.
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    datetime: DateTime
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE",
+  "useWhereFilter": true,
+  "pluralizeFields": true,
+  "useTemporalScalars": true
+}
+----
+
+**Output**
+
+== Output
+
+.Augmented Schema
+[source,graphql]
+----
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Movie {
+  datetime: DateTime
+  id: ID
+}
+
+type Mutation {
+  createMovie(datetime: DateTime, id: ID): Movie!
+  "Deletes Movie and returns the type itself"
+  deleteMovie(id: ID): Movie
+  mergeMovie(datetime: DateTime, id: ID): Movie!
+  updateMovie(datetime: DateTime, id: ID): Movie
+}
+
+type Query {
+  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+}
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+enum SortDirection {
+  "Sort by field values in ascending order."
+  ASC
+  "Sort by field values in descending order."
+  DESC
+}
+
+"Scalar DateTime"
+scalar DateTime
+
+input MovieOptions {
+  "Defines the maximum amount of records returned"
+  limit: Int
+  "Defines the amount of records to be skipped"
+  skip: Int
+  "Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array."
+  sort: [MovieSort!]
+}
+
+"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object."
+input MovieSort {
+  datetime: SortDirection
+  id: SortDirection
+}
+
+input MovieWhere {
+  AND: [MovieWhere!]
+  NOT: [MovieWhere!]
+  OR: [MovieWhere!]
+  datetime: DateTime
+  datetime_gt: DateTime
+  datetime_gte: DateTime
+  datetime_in: [DateTime]
+  datetime_lt: DateTime
+  datetime_lte: DateTime
+  datetime_not: DateTime
+  datetime_not_in: [DateTime]
+  id: ID
+  id_contains: ID
+  id_ends_with: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_lt: ID
+  id_lte: ID
+  id_matches: ID
+  id_not: ID
+  id_not_contains: ID
+  id_not_ends_with: ID
+  id_not_in: [ID]
+  id_not_starts_with: ID
+  id_starts_with: ID
+}
+
+----


### PR DESCRIPTION
With these changes a new configuration param `useTemporalScalars` was introduced. With this configuration enabled, neo4js' temporales like `Date`, `Time`, `LocalTime`, `DateTime` and `LocalDateTime` are used as scalars (strings).

resolves #223
resolves #109
resolves #108
resolves #93