### PR TITLE
Use graphql infrastructure to parse requests

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/Cypher.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Cypher.kt
@@ -4,5 +4,4 @@ import graphql.schema.GraphQLType
 
 data class Cypher @JvmOverloads constructor(val query: String, val params: Map<String, Any?> = emptyMap(), var type: GraphQLType? = null, val variable: String) {
     fun with(p: Map<String, Any?>) = this.copy(params = this.params + p)
-    fun escapedQuery() = query.replace("\"", "\\\"").replace("'", "\\'")
 }

--- a/core/src/main/kotlin/org/neo4j/graphql/DynamicProperties.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/DynamicProperties.kt
@@ -32,6 +32,16 @@ object DynamicProperties {
         return when (input) {
             !is Value<*> -> throw CoercingParseLiteralException("Expected AST type 'StringValue' but was '${input::class.java.simpleName}'.")
             is NullValue -> null
+            is ObjectValue -> input.objectFields.map { it.name to parseNested(it.value, variables) }.toMap()
+            else -> Assert.assertShouldNeverHappen("Only maps structures are expected")
+        }
+    }
+
+    @Throws(CoercingParseLiteralException::class)
+    private fun parseNested(input: Any, variables: Map<String, Any>): Any? {
+        return when (input) {
+            !is Value<*> -> throw CoercingParseLiteralException("Expected AST type 'StringValue' but was '${input::class.java.simpleName}'.")
+            is NullValue -> null
             is FloatValue -> input.value
             is StringValue -> input.value
             is IntValue -> input.value

--- a/core/src/main/kotlin/org/neo4j/graphql/InvalidQueryException.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/InvalidQueryException.kt
@@ -1,0 +1,5 @@
+package org.neo4j.graphql
+
+import graphql.GraphQLError
+
+class InvalidQueryException(@Suppress("MemberVisibilityCanBePrivate") val error: GraphQLError) : RuntimeException(error.message)

--- a/core/src/main/kotlin/org/neo4j/graphql/Translator.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Translator.kt
@@ -1,93 +1,37 @@
 package org.neo4j.graphql
 
-import graphql.execution.MergedField
-import graphql.language.Document
-import graphql.language.Field
-import graphql.language.FragmentDefinition
-import graphql.language.OperationDefinition
-import graphql.language.OperationDefinition.Operation.MUTATION
-import graphql.language.OperationDefinition.Operation.QUERY
-import graphql.parser.InvalidSyntaxException
-import graphql.parser.Parser
-import graphql.schema.DataFetchingEnvironmentImpl.newDataFetchingEnvironment
-import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLObjectType
+import graphql.ExceptionWhileDataFetching
+import graphql.ExecutionInput
+import graphql.GraphQL
+import graphql.InvalidSyntaxError
 import graphql.schema.GraphQLSchema
-import java.math.BigDecimal
-import java.math.BigInteger
+import graphql.validation.ValidationError
 
 class Translator(val schema: GraphQLSchema) {
+
+    class CypherHolder(var cypher: Cypher?)
+
+    private val gql: GraphQL = GraphQL.newGraphQL(schema).build()
 
     @JvmOverloads
     @Throws(OptimizedQueryException::class)
     fun translate(query: String, params: Map<String, Any?> = emptyMap(), ctx: QueryContext = QueryContext()): List<Cypher> {
-        val ast = parse(query) // todo preparsedDocumentProvider
-        val fragments = ast.definitions.filterIsInstance<FragmentDefinition>().associateBy { it.name }
-        return ast.definitions.filterIsInstance<OperationDefinition>()
-            .filter { it.operation == QUERY || it.operation == MUTATION } // todo variableDefinitions, directives, name
-            .flatMap { operationDefinition ->
-                operationDefinition.selectionSet.selections
-                    .filterIsInstance<Field>() // FragmentSpread, InlineFragment
-                    .map { field ->
-                        val cypher = toQuery(operationDefinition.operation, field, fragments, params, ctx)
-                        val resolvedParams = cypher.params.mapValues { toBoltValue(it.value) }
-                        cypher.with(resolvedParams)
-                    }
-            }
-    }
-
-    private fun toBoltValue(value: Any?) = when (value) {
-        is BigInteger -> value.longValueExact()
-        is BigDecimal -> value.toDouble()
-        else -> value
-    }
-
-    private fun toQuery(op: OperationDefinition.Operation,
-            field: Field,
-            fragments: Map<String, FragmentDefinition?>,
-            variables: Map<String, Any?>,
-            ctx: QueryContext = QueryContext()
-    ): Cypher {
-        val name = field.name
-        val operationObjectType: GraphQLObjectType
-        val fieldDefinition: GraphQLFieldDefinition
-        when (op) {
-            QUERY -> {
-                operationObjectType = schema.queryType
-                fieldDefinition = operationObjectType.getRelevantFieldDefinition(name)
-                        ?: throw IllegalArgumentException("Unknown Query $name available queries: " + (operationObjectType.getRelevantFieldDefinitions()).joinToString { it.name })
-            }
-            MUTATION -> {
-                operationObjectType = schema.mutationType
-                fieldDefinition = operationObjectType.getRelevantFieldDefinition(name)
-                        ?: throw IllegalArgumentException("Unknown Mutation $name available mutations: " + (operationObjectType.getRelevantFieldDefinitions()).joinToString { it.name })
-            }
-            else -> throw IllegalArgumentException("$op is not supported")
-        }
-        val dataFetcher = schema.codeRegistry.getDataFetcher(operationObjectType, fieldDefinition)
-                ?: throw IllegalArgumentException("no data fetcher found for ${op.name.toLowerCase()} $name")
-
-
-        return dataFetcher.get(newDataFetchingEnvironment()
-            .mergedField(MergedField.newMergedField(field).build())
-            .parentType(operationObjectType)
-            .graphQLSchema(schema)
-            .fragmentsByName(fragments)
+        val cypherHolder = CypherHolder(null)
+        val executionInput = ExecutionInput.newExecutionInput()
+            .query(query)
+            .variables(params)
             .context(ctx)
-            .localContext(ctx)
-            .fieldDefinition(fieldDefinition)
-            .variables(variables)
-            .build()) as? Cypher
-                ?: throw java.lang.IllegalStateException("not supported")
-    }
-
-    private fun parse(query: String): Document {
-        try {
-            val parser = Parser()
-            return parser.parseDocument(query)
-        } catch (e: InvalidSyntaxException) {
-            // todo proper structured error
-            throw e
+            .localContext(cypherHolder)
+            .build()
+        val result = gql.execute(executionInput)
+        result.errors?.forEach {
+            when (it) {
+                is ExceptionWhileDataFetching -> throw it.exception
+                is ValidationError -> throw InvalidQueryException(it)
+                is InvalidSyntaxError -> throw InvalidQueryException(it)
+            }
         }
+
+        return listOf(requireNotNull(cypherHolder.cypher))
     }
 }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/AugmentFieldHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/AugmentFieldHandler.kt
@@ -56,6 +56,16 @@ class AugmentFieldHandler(
                     fieldBuilder.inputValueDefinition(input(ProjectionBase.ORDER_BY, orderType))
                 }
             }
+            if (!schemaConfig.useWhereFilter && schemaConfig.query.enabled && !schemaConfig.query.exclude.contains(fieldType.name)) {
+                // legacy support
+                val relevantFields = fieldType
+                    .getScalarFields()
+                    .filter { scalarField -> field.inputValueDefinitions.find { it.name == scalarField.name } == null }
+                    .filter { it.dynamicPrefix() == null } // TODO currently we do not support filtering on dynamic properties
+                getInputValueDefinitions(relevantFields, true, { true }).forEach {
+                    fieldBuilder.inputValueDefinition(it)
+                }
+            }
         }
 
         val filterFieldName = if (schemaConfig.useWhereFilter) ProjectionBase.WHERE else ProjectionBase.FILTER

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcher.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/BaseDataFetcher.kt
@@ -11,11 +11,12 @@ import org.neo4j.cypherdsl.core.renderer.Configuration
 import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.graphql.Cypher
 import org.neo4j.graphql.SchemaConfig
+import org.neo4j.graphql.Translator
 import org.neo4j.graphql.aliasOrName
 import org.neo4j.graphql.handler.projection.ProjectionBase
 
 /**
- * The is a base class for the implementation of graphql data fetcher used in this project
+ * This is a base class for the implementation of graphql data fetcher used in this project
  */
 abstract class BaseDataFetcher(schemaConfig: SchemaConfig) : ProjectionBase(schemaConfig), DataFetcher<Cypher> {
 
@@ -38,8 +39,10 @@ abstract class BaseDataFetcher(schemaConfig: SchemaConfig) : ProjectionBase(sche
         val params = statement.parameters.mapValues { (_, value) ->
             (value as? VariableReference)?.let { env.variables[it.name] } ?: value
         }
-
         return Cypher(query, params, env.fieldDefinition.type, variable = field.aliasOrName())
+            .also {
+                (env.getLocalContext() as? Translator.CypherHolder)?.apply { this.cypher = it }
+            }
     }
 
     /**

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
@@ -33,11 +33,14 @@ class MergeOrUpdateHandler private constructor(private val merge: Boolean, schem
             }
 
             val relevantFields = type.getScalarFields()
-            val mergeField = buildFieldDefinition("merge", type, relevantFields, nullableResult = false)
+            val idField = type.getIdField()
+                    ?: throw IllegalStateException("Cannot resolve id field for type ${type.name}")
+
+            val mergeField = buildFieldDefinition("merge", type, relevantFields, nullableResult = false, forceOptionalProvider = { it != idField })
                 .build()
             addMutationField(mergeField)
 
-            val updateField = buildFieldDefinition("update", type, relevantFields, nullableResult = true)
+            val updateField = buildFieldDefinition("update", type, relevantFields, nullableResult = true, forceOptionalProvider = { it != idField })
                 .build()
             addMutationField(updateField)
         }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
@@ -32,7 +32,7 @@ class QueryHandler private constructor(schemaConfig: SchemaConfig) : BaseDataFet
             val arguments = if (schemaConfig.useWhereFilter) {
                 listOf(input(WHERE, TypeName(filterTypeName)))
             } else {
-                getInputValueDefinitions(relevantFields, { true }) +
+                getInputValueDefinitions(relevantFields, true, { true }) +
                         input(FILTER, TypeName(filterTypeName))
             }
 

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
@@ -268,7 +268,7 @@ open class ProjectionBase(
         }
         if (nodeType is GraphQLInterfaceType
             && !hasTypeName
-            && (env.getLocalContext() as? QueryContext)?.queryTypeOfInterfaces == true
+            && (env.getContext() as? QueryContext)?.queryTypeOfInterfaces == true
         ) {
             // for interfaces the typename is required to determine the correct implementation
             val (pro, sub) = projectField(propertyContainer, variable, Field(TYPE_NAME), nodeType, env, variableSuffix)

--- a/core/src/test/kotlin/org/neo4j/graphql/TranslatorExceptionTests.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/TranslatorExceptionTests.kt
@@ -1,6 +1,5 @@
 package org.neo4j.graphql
 
-import graphql.parser.InvalidSyntaxException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest
@@ -19,7 +18,7 @@ class TranslatorExceptionTests : AsciiDocTestSuite("translator-tests1.adoc") {
         val translator = Translator(SchemaBuilder.buildSchema(schema))
         return listOf(
                 DynamicTest.dynamicTest("unknownType") {
-                    Assertions.assertThrows(IllegalArgumentException::class.java) {
+                    Assertions.assertThrows(InvalidQueryException::class.java) {
                         translator.translate("""
                         {
                           company {
@@ -30,7 +29,7 @@ class TranslatorExceptionTests : AsciiDocTestSuite("translator-tests1.adoc") {
                     }
                 },
                 DynamicTest.dynamicTest("mutation") {
-                    Assertions.assertThrows(InvalidSyntaxException::class.java) {
+                    Assertions.assertThrows(InvalidQueryException::class.java) {
                         translator.translate("""
                         {
                           createPerson()

--- a/core/src/test/resources/augmentation-tests.adoc
+++ b/core/src/test/resources/augmentation-tests.adoc
@@ -379,7 +379,7 @@ schema {
 }
 
 interface HasMovies {
-  movies(filter: _MovieFilter, first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
+  movies(filter: _MovieFilter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
 }
 
 type Knows0 {
@@ -437,7 +437,7 @@ type Person4 {
 
 type Person5 implements HasMovies {
   id: ID!
-  movies(filter: _MovieFilter, first: Int, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
+  movies(filter: _MovieFilter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_MovieOrdering!]): [Movie]
 }
 
 type Publisher {
@@ -447,16 +447,16 @@ type Publisher {
 type Query {
   PersonByLocation(first: Int, location: _Neo4jPointInput, offset: Int, orderBy: [_Person0Ordering!]): [Person0!]!
   hasMovies(filter: _HasMoviesFilter, first: Int, offset: Int): [HasMovies!]!
-  knows0(filter: _Knows0Filter, first: Int, id: ID, offset: Int, orderBy: [_Knows0Ordering!]): [Knows0!]!
-  knows1(filter: _Knows1Filter, first: Int, id: ID, offset: Int, orderBy: [_Knows1Ordering!]): [Knows1!]!
+  knows0(filter: _Knows0Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_Knows0Ordering!]): [Knows0!]!
+  knows1(filter: _Knows1Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_Knows1Ordering!]): [Knows1!]!
   knows4(_id: ID, filter: _Knows4Filter, first: Int, offset: Int, orderBy: [_Knows4Ordering!]): [Knows4!]!
-  movie(filter: _MovieFilter, first: Int, id: ID, offset: Int, orderBy: [_MovieOrdering!]): [Movie!]!
-  person1(born: _Neo4jDateInput, filter: _Person1Filter, first: Int, name: String, offset: Int, orderBy: [_Person1Ordering!]): [Person1!]!
-  person2(age: [Int], born: _Neo4jDateTimeInput, filter: _Person2Filter, first: Int, name: String, offset: Int, orderBy: [_Person2Ordering!]): [Person2!]!
-  person3(born: _Neo4jLocalTimeInput, filter: _Person3Filter, first: Int, name: String, offset: Int, orderBy: [_Person3Ordering!]): [Person3!]!
-  person4(born: _Neo4jLocalDateTimeInput, filter: _Person4Filter, first: Int, id: ID, name: String, offset: Int, orderBy: [_Person4Ordering!]): [Person4!]!
-  person5(filter: _Person5Filter, first: Int, id: ID, offset: Int, orderBy: [_Person5Ordering!]): [Person5!]!
-  publisher(filter: _PublisherFilter, first: Int, name: ID, offset: Int, orderBy: [_PublisherOrdering!]): [Publisher!]!
+  movie(filter: _MovieFilter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_MovieOrdering!]): [Movie!]!
+  person1(born: _Neo4jDateInput, born_in: [_Neo4jDateInput!], born_not: _Neo4jDateInput, born_not_in: [_Neo4jDateInput!], filter: _Person1Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person1Ordering!]): [Person1!]!
+  person2(age: [Int], age_gt: [Int], age_gte: [Int], age_in: [Int!], age_lt: [Int], age_lte: [Int], age_not: [Int], age_not_in: [Int!], born: _Neo4jDateTimeInput, born_in: [_Neo4jDateTimeInput!], born_not: _Neo4jDateTimeInput, born_not_in: [_Neo4jDateTimeInput!], filter: _Person2Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person2Ordering!]): [Person2!]!
+  person3(born: _Neo4jLocalTimeInput, born_in: [_Neo4jLocalTimeInput!], born_not: _Neo4jLocalTimeInput, born_not_in: [_Neo4jLocalTimeInput!], filter: _Person3Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person3Ordering!]): [Person3!]!
+  person4(born: _Neo4jLocalDateTimeInput, born_in: [_Neo4jLocalDateTimeInput!], born_not: _Neo4jLocalDateTimeInput, born_not_in: [_Neo4jLocalDateTimeInput!], filter: _Person4Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person4Ordering!]): [Person4!]!
+  person5(filter: _Person5Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_Person5Ordering!]): [Person5!]!
+  publisher(filter: _PublisherFilter, first: Int, name: ID, name_contains: ID, name_ends_with: ID, name_gt: ID, name_gte: ID, name_in: [ID!], name_lt: ID, name_lte: ID, name_matches: ID, name_not: ID, name_not_contains: ID, name_not_ends_with: ID, name_not_in: [ID!], name_not_starts_with: ID, name_starts_with: ID, offset: Int, orderBy: [_PublisherOrdering!]): [Publisher!]!
 }
 
 type _Neo4jDate {

--- a/core/src/test/resources/cypher-directive-tests.adoc
+++ b/core/src/test/resources/cypher-directive-tests.adoc
@@ -401,7 +401,7 @@ RETURN user AS user
 [source,graphql]
 ----
 query queriesRootQuery {
-  person { id, data }
+  person { id, data { firstName } }
 }
 ----
 

--- a/core/src/test/resources/movie-tests.adoc
+++ b/core/src/test/resources/movie-tests.adoc
@@ -87,7 +87,9 @@ type Book {
 }
 enum _MovieOrdering {
   title_desc,
-  title_asc
+  title_asc,
+  year_desc,
+  plot_desc
 }
 enum _GenreOrdering {
   name_desc,

--- a/core/src/test/resources/schema-operations-tests.adoc
+++ b/core/src/test/resources/schema-operations-tests.adoc
@@ -37,7 +37,7 @@ schema {
 }
 
 type CustomQueryType {
-  location(filter: _LocationFilter, first: Int, name: String, offset: Int, orderBy: [_LocationOrdering!]): [Location!]!
+  location(filter: _LocationFilter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_LocationOrdering!]): [Location!]!
   person(name: String): Person
 }
 
@@ -133,8 +133,8 @@ schema {
 }
 
 type CustomQueryType {
-  Location(filter: _LocationFilter, first: Int, name: String, offset: Int, orderBy: [_LocationOrdering!]): [Location!]!
-  Person(filter: _PersonFilter, first: Int, name: String, offset: Int, orderBy: [_PersonOrdering!]): [Person!]!
+  Location(filter: _LocationFilter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_LocationOrdering!]): [Location!]!
+  Person(filter: _PersonFilter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_PersonOrdering!]): [Person!]!
   person(name: String): Person
 }
 

--- a/core/src/test/resources/tck-test-files/schema/directives/ignore.adoc
+++ b/core/src/test/resources/tck-test-files/schema/directives/ignore.adoc
@@ -43,8 +43,8 @@ type Mutation {
   createUser(id: ID!, password: String!, username: String!): User!
   "Deletes User and returns the type itself"
   deleteUser(id: ID!): User
-  mergeUser(id: ID!, password: String!, username: String!): User!
-  updateUser(id: ID!, password: String!, username: String!): User
+  mergeUser(id: ID!, password: String, username: String): User!
+  updateUser(id: ID!, password: String, username: String): User
 }
 
 type Query {

--- a/core/src/test/resources/translator-tests1.adoc
+++ b/core/src/test/resources/translator-tests1.adoc
@@ -31,15 +31,18 @@ type Death implements Temporal @relation(name:"DIED",from:"who",to:"where") {
 interface Location {
   name: String
   founded: Person @relation(name:"FOUNDED", direction: IN)
+  sort_Arg: String
 }
 type City implements Location {
   name: String
   founded: Person @relation(name:"FOUNDED", direction: IN)
+  sort_Arg: String
   city_Arg: String
 }
 type Village implements Location {
   name: String
   founded: Person @relation(name:"FOUNDED", direction: IN)
+  sort_Arg: String
   villageArg: String
 }
 # enum _PersonOrdering { name_asc, name_desc, age_asc, age_desc }
@@ -430,14 +433,14 @@ RETURN person {
 .GraphQL-Query
 [source,graphql]
 ----
-{ person { name age livesIn(name:"Berlin") { name } } }
+{ person { name age livedIn(name:"Berlin") { name } } }
 ----
 
 .Cypher params
 [source,json]
 ----
 {
-  "personLivesInName" : "Berlin"
+  "personLivedInName" : "Berlin"
 }
 ----
 
@@ -447,16 +450,16 @@ RETURN person {
 MATCH (person:Person)
 CALL {
 	WITH person
-	OPTIONAL MATCH (person)-[:LIVES_IN]->(personLivesIn:Location)
-	WHERE personLivesIn.name = $personLivesInName
-	RETURN personLivesIn {
+	MATCH (person)-[:LIVED_IN]->(personLivedIn:Location)
+	WHERE personLivedIn.name = $personLivedInName
+	RETURN collect(personLivedIn {
 		.name
-	} AS personLivesIn LIMIT 1
+	}) AS personLivedIn
 }
 RETURN person {
 	.name,
 	.age,
-	livesIn: personLivesIn
+	livedIn: personLivedIn
 } AS person
 ----
 
@@ -485,7 +488,7 @@ MATCH (person:Person) RETURN person { .age } AS person ORDER BY person.age DESC,
 .GraphQL-Query
 [source,graphql]
 ----
- { location(orderBy:[city_Arg_desc]) { name } }
+ { location(orderBy:[sort_Arg_desc]) { name } }
 ----
 
 .Cypher params
@@ -497,9 +500,10 @@ MATCH (person:Person) RETURN person { .age } AS person ORDER BY person.age DESC,
 .Cypher
 [source,cypher]
 ----
-MATCH (location: Location)
-RETURN location { .name } AS location
-ORDER BY location.city_Arg DESC
+MATCH (location:Location)
+RETURN location {
+	.name
+} AS location ORDER BY location.sort_Arg DESC
 ----
 
 === named fragment multi field


### PR DESCRIPTION
Using the graphql infrastructure for parsing the request ensures that:
* the request is compliant with the schema
* internally we can rely on `DataFetchingEnvironment` being correctly initialized