### PR TITLE
Utilize graphql framework to handle fragments correctly

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/DynamicProperties.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/DynamicProperties.kt
@@ -48,7 +48,7 @@ object DynamicProperties {
             is BooleanValue -> input.isValue
             is EnumValue -> input.name
             is VariableReference -> variables[input.name]
-            is ArrayValue -> input.values.map { v -> parse(v, variables) }
+            is ArrayValue -> input.values.map { v -> parseNested(v, variables) }
             is ObjectValue -> throw IllegalArgumentException("deep structures not supported for dynamic properties")
             else -> Assert.assertShouldNeverHappen("We have covered all Value types")
         }

--- a/core/src/main/kotlin/org/neo4j/graphql/ExtensionFunctions.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/ExtensionFunctions.kt
@@ -6,10 +6,6 @@ import graphql.schema.GraphQLOutputType
 import org.neo4j.cypherdsl.core.*
 import java.util.*
 
-fun <T> Iterable<T>.joinNonEmpty(separator: CharSequence = ", ", prefix: CharSequence = "", postfix: CharSequence = "", limit: Int = -1, truncated: CharSequence = "...", transform: ((T) -> CharSequence)? = null): String {
-    return if (iterator().hasNext()) joinTo(StringBuilder(), separator, prefix, postfix, limit, truncated, transform).toString() else ""
-}
-
 fun queryParameter(value: Any?, vararg parts: String?): Parameter<*> {
     val name = when (value) {
         is VariableReference -> value.name
@@ -22,7 +18,6 @@ fun Expression.collect(type: GraphQLOutputType) = if (type.isList()) Functions.c
 fun StatementBuilder.OngoingReading.withSubQueries(subQueries: List<Statement>) = subQueries.fold(this, { it, sub -> it.call(sub) })
 
 fun normalizeName(vararg parts: String?) = parts.mapNotNull { it?.capitalize() }.filter { it.isNotBlank() }.joinToString("").decapitalize()
-//fun normalizeName(vararg parts: String?) = parts.filterNot { it.isNullOrBlank() }.joinToString("_")
 
 fun PropertyContainer.id(): FunctionInvocation = when (this) {
     is Node -> Functions.id(this)
@@ -35,3 +30,7 @@ fun String.toCamelCase(): String = Regex("[\\W_]([a-z])").replace(this) { it.gro
 fun <T> Optional<T>.unwrap(): T? = orElse(null)
 
 fun String.asDescription() = Description(this, null, this.contains("\n"))
+
+fun String.capitalize(): String = replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+fun String.decapitalize(): String = replaceFirstChar { it.lowercase(Locale.getDefault()) }
+fun String.toUpperCase(): String = uppercase(Locale.getDefault())

--- a/core/src/main/kotlin/org/neo4j/graphql/NoOpCoercing.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/NoOpCoercing.kt
@@ -3,9 +3,9 @@ package org.neo4j.graphql
 import graphql.schema.Coercing
 
 object NoOpCoercing : Coercing<Any, Any> {
-    override fun parseLiteral(input: Any?) = input
+    override fun parseLiteral(input: Any?) = input?.toJavaValue()
 
     override fun serialize(dataFetcherResult: Any?) = dataFetcherResult
 
-    override fun parseValue(input: Any?) = input
+    override fun parseValue(input: Any) = input.toJavaValue()
 }

--- a/core/src/main/kotlin/org/neo4j/graphql/QueryContext.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/QueryContext.kt
@@ -2,7 +2,7 @@ package org.neo4j.graphql
 
 data class QueryContext @JvmOverloads constructor(
         /**
-         * if true the <code>__typename</code> will be always returned for interfaces, no matter if it was queried or not
+         * if true the <code>__typename</code> will always be returned for interfaces, no matter if it was queried or not
          */
         var queryTypeOfInterfaces: Boolean = false,
 

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/CreateTypeHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/CreateTypeHandler.kt
@@ -84,8 +84,8 @@ class CreateTypeHandler private constructor(schemaConfig: SchemaConfig) : BaseDa
         val additionalTypes = (type as? GraphQLObjectType)?.interfaces?.map { it.name } ?: emptyList()
         val node = org.neo4j.cypherdsl.core.Cypher.node(type.name, *additionalTypes.toTypedArray()).named(variable)
 
-        val properties = properties(variable, field.arguments)
-        val (mapProjection, subQueries) = projectFields(node, field, type, env)
+        val properties = properties(variable, env.arguments)
+        val (mapProjection, subQueries) = projectFields(node, type, env)
 
         return org.neo4j.cypherdsl.core.Cypher.create(node.withProperties(*properties))
             .with(node)

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/CypherDirectiveHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/CypherDirectiveHandler.kt
@@ -33,14 +33,14 @@ class CypherDirectiveHandler(schemaConfig: SchemaConfig) : BaseDataFetcher(schem
 
         val node = org.neo4j.cypherdsl.core.Cypher.anyNode(variable)
         val ctxVariable = node.requiredSymbolicName
-        val nestedQuery = cypherDirective(ctxVariable, fieldDefinition, field, cypherDirective, null, env)
+        val nestedQuery = cypherDirective(ctxVariable, fieldDefinition, env.arguments, cypherDirective, null)
 
         return org.neo4j.cypherdsl.core.Cypher.call(nestedQuery)
             .let { reading ->
                 if (type == null || cypherDirective.passThrough) {
                     reading.returning(ctxVariable.`as`(field.aliasOrName()))
                 } else {
-                    val (fieldProjection, nestedSubQueries) = projectFields(node, field, type, env)
+                    val (fieldProjection, nestedSubQueries) = projectFields(node, type, env)
                     reading
                         .withSubQueries(nestedSubQueries)
                         .returning(ctxVariable.project(fieldProjection).`as`(field.aliasOrName()))

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/DeleteHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/DeleteHandler.kt
@@ -90,7 +90,7 @@ class DeleteHandler private constructor(schemaConfig: SchemaConfig) : BaseDataFe
                 .where(where)
         }
         val deletedElement = propertyContainer.requiredSymbolicName.`as`("toDelete")
-        val (mapProjection, subQueries) = projectFields(propertyContainer, field, type, env)
+        val (mapProjection, subQueries) = projectFields(propertyContainer, type, env)
 
         val projection = propertyContainer.project(mapProjection).`as`(variable)
         return select

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/MergeOrUpdateHandler.kt
@@ -115,8 +115,8 @@ class MergeOrUpdateHandler private constructor(private val merge: Boolean, schem
                 org.neo4j.cypherdsl.core.Cypher.match(node).where(where)
             }
         }
-        val properties = properties(variable, field.arguments)
-        val (mapProjection, subQueries) = projectFields(propertyContainer, field, type, env)
+        val properties = properties(variable, env.arguments)
+        val (mapProjection, subQueries) = projectFields(propertyContainer, type, env)
 
         return select
             .mutate(propertyContainer, org.neo4j.cypherdsl.core.Cypher.mapOf(*properties))

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/QueryHandler.kt
@@ -113,20 +113,20 @@ class QueryHandler private constructor(schemaConfig: SchemaConfig) : BaseDataFet
 
         val ongoingReading = if ((env.getContext() as? QueryContext)?.optimizedQuery?.contains(QueryContext.OptimizationStrategy.FILTER_AS_MATCH) == true) {
 
-            OptimizedFilterHandler(type, schemaConfig).generateFilterQuery(variable, fieldDefinition, field, match, propertyContainer, env.variables)
+            OptimizedFilterHandler(type, schemaConfig).generateFilterQuery(variable, fieldDefinition, env.arguments, match, propertyContainer, env.variables)
 
         } else {
 
-            val where = where(propertyContainer, fieldDefinition, type, field, env.variables)
+            val where = where(propertyContainer, fieldDefinition, type, env.arguments, env.variables)
             match.where(where)
         }
 
-        val (projectionEntries, subQueries) = projectFields(propertyContainer, field, type, env)
+        val (projectionEntries, subQueries) = projectFields(propertyContainer, type, env)
         val mapProjection = propertyContainer.project(projectionEntries).`as`(field.aliasOrName())
         return ongoingReading
             .withSubQueries(subQueries)
             .returning(mapProjection)
-            .skipLimitOrder(propertyContainer.requiredSymbolicName, fieldDefinition, field, env)
+            .skipLimitOrder(propertyContainer.requiredSymbolicName, fieldDefinition, env.arguments)
             .build()
     }
 }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/relation/CreateRelationHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/relation/CreateRelationHandler.kt
@@ -61,14 +61,14 @@ class CreateRelationHandler private constructor(schemaConfig: SchemaConfig) : Ba
 
     override fun generateCypher(variable: String, field: Field, env: DataFetchingEnvironment): Statement {
 
-        val properties = properties(variable, field.arguments)
+        val properties = properties(variable, env.arguments)
 
         val arguments = field.arguments.associateBy { it.name }
         val (startNode, startWhere) = getRelationSelect(true, arguments)
         val (endNode, endWhere) = getRelationSelect(false, arguments)
 
         val withAlias = startNode.`as`(variable)
-        val (mapProjection, subQueries) = projectFields(startNode, withAlias.asName(), field, type, env)
+        val (mapProjection, subQueries) = projectFields(startNode, type, env, withAlias.asName())
         return org.neo4j.cypherdsl.core.Cypher.match(startNode).where(startWhere)
             .match(endNode).where(endWhere)
             .merge(relation.createRelation(startNode, endNode).withProperties(*properties))

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/relation/CreateRelationTypeHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/relation/CreateRelationTypeHandler.kt
@@ -132,13 +132,13 @@ class CreateRelationTypeHandler private constructor(schemaConfig: SchemaConfig) 
     }
 
     override fun generateCypher(variable: String, field: Field, env: DataFetchingEnvironment): Statement {
-        val properties = properties(variable, field.arguments)
+        val properties = properties(variable, env.arguments)
 
         val arguments = field.arguments.associateBy { it.name }
         val (startNode, startWhere) = getRelationSelect(true, arguments)
         val (endNode, endWhere) = getRelationSelect(false, arguments)
         val relName = name(variable)
-        val (mapProjection, subQueries) = projectFields(startNode, relName, field, type, env)
+        val (mapProjection, subQueries) = projectFields(startNode, type, env, relName)
 
         return org.neo4j.cypherdsl.core.Cypher.match(startNode).where(startWhere)
             .match(endNode).where(endWhere)
@@ -151,7 +151,7 @@ class CreateRelationTypeHandler private constructor(schemaConfig: SchemaConfig) 
 
     companion object {
         private fun normalizeFieldName(relFieldName: String?, name: String): String {
-            // TODO b/c we need to stay backwards compatible this is not caml case but with underscore
+            // TODO b/c we need to stay backwards compatible this is not camel-case but with underscore
             //val filedName = normalizeName(relFieldName, name)
             return "${relFieldName}_${name}"
         }

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/relation/DeleteRelationHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/relation/DeleteRelationHandler.kt
@@ -46,7 +46,7 @@ class DeleteRelationHandler private constructor(schemaConfig: SchemaConfig) : Ba
         val relName = org.neo4j.cypherdsl.core.Cypher.name("r")
 
         val withAlias = startNode.`as`(variable)
-        val (mapProjection, subQueries) = projectFields(startNode, withAlias.asName(), field, type, env)
+        val (mapProjection, subQueries) = projectFields(startNode, type, env, withAlias.asName())
 
         return org.neo4j.cypherdsl.core.Cypher
             .match(startNode).where(startWhere)

--- a/core/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
+++ b/core/src/test/kotlin/org/neo4j/graphql/utils/AsciiDocTestSuite.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest
 import java.io.File
 import java.io.FileWriter
+import java.math.BigInteger
 import java.net.URI
 import java.util.*
 import java.util.regex.Pattern
@@ -289,6 +290,7 @@ open class AsciiDocTestSuite(
         fun fixNumber(v: Any?): Any? = when (v) {
             is Float -> v.toDouble()
             is Int -> v.toLong()
+            is BigInteger -> v.toLong()
             is Iterable<*> -> v.map { fixNumber(it) }
             is Sequence<*> -> v.map { fixNumber(it) }
             is Map<*, *> -> v.mapValues { fixNumber(it.value) }

--- a/core/src/test/resources/cypher-directive-tests.adoc
+++ b/core/src/test/resources/cypher-directive-tests.adoc
@@ -89,14 +89,16 @@ query($pname:String) { p3(name:$pname) { id }}
 .Cypher params
 [source,json]
 ----
-{"pname":"foo"}
+{
+  "p3Name" : "foo"
+}
 ----
 
 .Cypher
 [source,cypher]
 ----
 CALL {
-	WITH $pname AS name
+	WITH $p3Name AS name
 	MATCH (p:Person) WHERE p.name = name RETURN p AS p3 LIMIT 1
 }
 RETURN p3 {

--- a/core/src/test/resources/filter-tests.adoc
+++ b/core/src/test/resources/filter-tests.adoc
@@ -694,7 +694,7 @@ RETURN person {
 [source,json]
 ----
 {
-  "filterCompany_id" : 1
+  "filterCompany_id" : "1"
 }
 ----
 
@@ -721,7 +721,7 @@ RETURN company {
 [source,json]
 ----
 {
-  "filterCompany_idIn" : [ 1, 2 ]
+  "filterCompany_idIn" : [ "1", "2" ]
 }
 ----
 
@@ -748,7 +748,7 @@ RETURN company {
 [source,json]
 ----
 {
-  "filterCompany_idNotIn" : [ 1, 2 ]
+  "filterCompany_idNotIn" : [ "1", "2" ]
 }
 ----
 
@@ -775,7 +775,7 @@ RETURN company {
 [source,json]
 ----
 {
-  "filterCompany_idNot" : 1
+  "filterCompany_idNot" : "1"
 }
 ----
 
@@ -2135,8 +2135,8 @@ RETURN person {
 [source,json]
 ----
 {
-  "filterPersonLocationAnd1Longitude" : 1,
-  "filterPersonLocationAnd2Latitude" : 2
+  "filterPersonLocationAnd1Longitude" : 1.0,
+  "filterPersonLocationAnd2Latitude" : 2.0
 }
 ----
 
@@ -2173,8 +2173,8 @@ RETURN person {
 [source,json]
 ----
 {
-  "filterPersonLocationNotAnd1Longitude" : 1,
-  "filterPersonLocationNotAnd2Latitude" : 2
+  "filterPersonLocationNotAnd1Longitude" : 1.0,
+  "filterPersonLocationNotAnd2Latitude" : 2.0
 }
 ----
 
@@ -2280,11 +2280,11 @@ RETURN person { .name } AS person
 ----
 {
   "filterPersonLocationDistance" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }
@@ -2327,11 +2327,11 @@ RETURN person {
 ----
 {
   "filterPersonLocationDistanceLt" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }
@@ -2374,11 +2374,11 @@ RETURN person {
 ----
 {
   "filterPersonLocationDistanceLte" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }
@@ -2421,11 +2421,11 @@ RETURN person {
 ----
 {
   "filterPersonLocationDistanceGt" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }
@@ -2468,11 +2468,11 @@ RETURN person {
 ----
 {
   "filterPersonLocationDistanceGte" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }
@@ -2585,8 +2585,8 @@ RETURN person {
 [source,cypher]
 ----
 MATCH (person:Person)
-WHERE (person.fun = $filterPersonFun
-	AND person.name = $filterPersonName)
+WHERE (person.name = $filterPersonName
+	AND person.fun = $filterPersonFun)
 RETURN person {
 	.name
 } AS person
@@ -2663,8 +2663,8 @@ RETURN person {
 [source,cypher]
 ----
 MATCH (person:Person)
-WHERE (person.fun = $filterPersonFun
-	AND NOT (person.name = $filterPersonNameNot))
+WHERE (NOT (person.name = $filterPersonNameNot)
+	AND person.fun = $filterPersonFun)
 RETURN person {
 	.name
 } AS person
@@ -3334,7 +3334,7 @@ query filterQuery($name: String) { person(filter: {name : $name}) { name }}
 [source,json]
 ----
 {
-  "name" : "Jane"
+  "filterPersonName" : "Jane"
 }
 ----
 
@@ -3342,7 +3342,7 @@ query filterQuery($name: String) { person(filter: {name : $name}) { name }}
 [source,cypher]
 ----
 MATCH (person:Person)
-WHERE person.name = $name
+WHERE person.name = $filterPersonName
 RETURN person {
 	.name
 } AS person

--- a/core/src/test/resources/issues/gh-112.adoc
+++ b/core/src/test/resources/issues/gh-112.adoc
@@ -70,7 +70,7 @@ query user( $uuid: ID ){
 [source,json]
 ----
 {
-  "uuid" : "2"
+  "userUuid" : "2"
 }
 ----
 
@@ -78,7 +78,7 @@ query user( $uuid: ID ){
 [source,cypher]
 ----
 MATCH (user:User)
-WHERE user.uuid = $uuid
+WHERE user.uuid = $userUuid
 CALL {
 	WITH user
 	MATCH (user)-[:ASSOCIATES_WITH]-(userAssociates:User)

--- a/core/src/test/resources/issues/gh-149.adoc
+++ b/core/src/test/resources/issues/gh-149.adoc
@@ -6,7 +6,7 @@
 
 [source,graphql,schema=true]
 ----
-interface Person {
+type Person {
     name: ID!
 }
 ----

--- a/core/src/test/resources/issues/gh-47.adoc
+++ b/core/src/test/resources/issues/gh-47.adoc
@@ -6,7 +6,7 @@
 
 [source,graphql,schema=true]
 ----
-interface Company {
+type Company {
     name: String
 }
 ----

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -9,4 +9,5 @@
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
+    <logger name="notprivacysafe.graphql.execution.ExecutionStrategy" level="ERROR"/>
 </configuration>

--- a/core/src/test/resources/movie-tests.adoc
+++ b/core/src/test/resources/movie-tests.adoc
@@ -1145,7 +1145,7 @@ RETURN user {
 [source,json]
 ----
 {
-  "rated_id" : 1
+  "rated_id" : "1"
 }
 ----
 
@@ -1289,7 +1289,7 @@ mutation {
 [source,json]
 ----
 {
-  "createUserUserId" : 1,
+  "createUserUserId" : "1",
   "createUserValidTypes" : [ "User" ]
 }
 ----
@@ -1355,8 +1355,8 @@ query {
 [source,json]
 ----
 {
-  "userBornAnd1Formatted" : "2015-06-24T12:50:35.556000000+01:00",
-  "userBornAnd2Year" : 2015
+  "userBornAnd1Year" : 2015,
+  "userBornAnd2Formatted" : "2015-06-24T12:50:35.556000000+01:00"
 }
 ----
 
@@ -1364,8 +1364,8 @@ query {
 [source,cypher]
 ----
 MATCH (user:User)
-WHERE (user.born = datetime($userBornAnd1Formatted)
-	AND user.born.year = $userBornAnd2Year)
+WHERE (user.born.year = $userBornAnd1Year
+	AND user.born = datetime($userBornAnd2Formatted))
 RETURN user {
 	born:  {
 		year: user.born.year

--- a/core/src/test/resources/optimized-query-for-filter.adoc
+++ b/core/src/test/resources/optimized-query-for-filter.adoc
@@ -274,15 +274,15 @@ RETURN movie {
 ----
 MATCH (movie:Movie)
 WITH movie
-MATCH (movie)<-[:DIRECTED]-(movieDirectedByEvery:Person)
-WHERE movieDirectedByEvery.name = $movieDirectedByEveryName
-WITH movie, size((movie)<-[:DIRECTED]-(:Person)) AS movieDirectedByEveryTotal, count(DISTINCT movieDirectedByEvery) AS movieDirectedByEveryCount
-WHERE movieDirectedByEveryTotal = movieDirectedByEveryCount
-WITH DISTINCT movie
 MATCH (movie)<-[:REVIEWED]-(movieReviewedByEvery:Person)
 WHERE movieReviewedByEvery.name = $movieReviewedByEveryName
 WITH movie, size((movie)<-[:REVIEWED]-(:Person)) AS movieReviewedByEveryTotal, count(DISTINCT movieReviewedByEvery) AS movieReviewedByEveryCount
 WHERE movieReviewedByEveryTotal = movieReviewedByEveryCount
+WITH DISTINCT movie
+MATCH (movie)<-[:DIRECTED]-(movieDirectedByEvery:Person)
+WHERE movieDirectedByEvery.name = $movieDirectedByEveryName
+WITH movie, size((movie)<-[:DIRECTED]-(:Person)) AS movieDirectedByEveryTotal, count(DISTINCT movieDirectedByEvery) AS movieDirectedByEveryCount
+WHERE movieDirectedByEveryTotal = movieDirectedByEveryCount
 WITH DISTINCT movie
 RETURN movie {
 	.title
@@ -451,11 +451,6 @@ RETURN movie { .title } AS movie
 ----
 MATCH (movie:Movie)
 WITH movie
-MATCH (movie)<-[:DIRECTED]-(movieDirectedByEvery:Person)
-WHERE movieDirectedByEvery.name = $movieDirectedByEveryName
-WITH movie, size((movie)<-[:DIRECTED]-(:Person)) AS movieDirectedByEveryTotal, count(DISTINCT movieDirectedByEvery) AS movieDirectedByEveryCount
-WHERE movieDirectedByEveryTotal = movieDirectedByEveryCount
-WITH DISTINCT movie
 MATCH (movie)<-[:REVIEWED]-(movieReviewedBySome:Person)
 WHERE movieReviewedBySome.name = $movieReviewedBySomeName
 WITH movie, movieReviewedBySome
@@ -463,6 +458,11 @@ MATCH (movieReviewedBySome)<-[:FOLLOWS]-(movieReviewedBySomeFollowedBySome:Perso
 WITH movie, movieReviewedBySomeFollowedBySome
 MATCH (movieReviewedBySomeFollowedBySome)-[:REVIEWED]->(movieReviewedBySomeFollowedBySomeReviewedMoviesSome:Movie)
 WHERE movieReviewedBySomeFollowedBySomeReviewedMoviesSome.released >= $movieReviewedBySomeFollowedBySomeReviewedMoviesSomeReleasedGte
+WITH DISTINCT movie
+MATCH (movie)<-[:DIRECTED]-(movieDirectedByEvery:Person)
+WHERE movieDirectedByEvery.name = $movieDirectedByEveryName
+WITH movie, size((movie)<-[:DIRECTED]-(:Person)) AS movieDirectedByEveryTotal, count(DISTINCT movieDirectedByEvery) AS movieDirectedByEveryCount
+WHERE movieDirectedByEveryTotal = movieDirectedByEveryCount
 WITH DISTINCT movie
 RETURN movie {
 	.title
@@ -974,8 +974,8 @@ RETURN person {
 [source,json]
 ----
 {
-  "personLocationNotAnd1Longitude" : 3,
-  "personLocationNotAnd2Latitude" : 3
+  "personLocationNotAnd1Longitude" : 3.0,
+  "personLocationNotAnd2Latitude" : 3.0
 }
 ----
 
@@ -1014,11 +1014,11 @@ RETURN person {
 ----
 {
   "personLocationDistanceLt" : {
-    "distance" : 3,
+    "distance" : 3.0,
     "point" : {
-      "longitude" : 1,
-      "latitude" : 2,
-      "height" : 3
+      "longitude" : 1.0,
+      "latitude" : 2.0,
+      "height" : 3.0
     }
   }
 }

--- a/core/src/test/resources/tck-test-files/cypher/pagination.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/pagination.adoc
@@ -151,13 +151,12 @@ query($skip: Int, $limit: Int) {
 }
 ----
 
-
 .Expected Cypher params
 [source,json]
 ----
 {
-  "limit" : 0,
-  "skip" : 0
+  "moviesLimit" : 0,
+  "moviesSkip" : 0
 }
 ----
 
@@ -167,7 +166,7 @@ query($skip: Int, $limit: Int) {
 MATCH (movies:Movie)
 RETURN movies {
 	.title
-} AS movies SKIP $skip LIMIT $limit
+} AS movies SKIP $moviesSkip LIMIT $moviesLimit
 ----
 
 === Skip + Limit with other variables
@@ -199,9 +198,9 @@ query($skip: Int, $limit: Int, $title: String) {
 [source,json]
 ----
 {
-  "limit" : 1,
-  "skip" : 2,
-  "title" : "some title"
+  "moviesLimit" : 1,
+  "moviesSkip" : 2,
+  "whereMoviesTitle" : "some title"
 }
 ----
 
@@ -209,10 +208,10 @@ query($skip: Int, $limit: Int, $title: String) {
 [source,cypher]
 ----
 MATCH (movies:Movie)
-WHERE movies.title = $title
+WHERE movies.title = $whereMoviesTitle
 RETURN movies {
 	.title
-} AS movies SKIP $skip LIMIT $limit
+} AS movies SKIP $moviesSkip LIMIT $moviesLimit
 ----
 
 === Default values
@@ -401,15 +400,14 @@ query($skip: Int, $limit: Int) {
 }
 ----
 
-
 .Expected Cypher params
 [source,json]
 ----
 {
   "actorsLimit" : 10,
-  "actorsSkip" : 0,
-  "limit" : 0,
-  "skip" : 0
+  "actorsMoviesLimit" : 0,
+  "actorsMoviesSkip" : 0,
+  "actorsSkip" : 0
 }
 ----
 
@@ -420,7 +418,7 @@ MATCH (actors:Actor)
 CALL {
 	WITH actors
 	MATCH (actors)-[:ACTS_IN]->(actorsMovies:Movie)
-	WITH actorsMovies SKIP $skip LIMIT $limit
+	WITH actorsMovies SKIP $actorsMoviesSkip LIMIT $actorsMoviesLimit
 	RETURN collect(actorsMovies {
 		.title
 	}) AS actorsMovies
@@ -459,16 +457,15 @@ query($skip: Int, $limit: Int, $title: String) {
 }
 ----
 
-
 .Expected Cypher params
 [source,json]
 ----
 {
   "actorsLimit" : 10,
+  "actorsMoviesLimit" : 1,
+  "actorsMoviesSkip" : 2,
   "actorsSkip" : 0,
-  "limit" : 1,
-  "skip" : 2,
-  "title" : "some title"
+  "whereActorsMoviesTitle" : "some title"
 }
 ----
 
@@ -479,8 +476,8 @@ MATCH (actors:Actor)
 CALL {
 	WITH actors
 	MATCH (actors)-[:ACTS_IN]->(actorsMovies:Movie)
-	WHERE actorsMovies.title = $title
-	WITH actorsMovies SKIP $skip LIMIT $limit
+	WHERE actorsMovies.title = $whereActorsMoviesTitle
+	WITH actorsMovies SKIP $actorsMoviesSkip LIMIT $actorsMoviesLimit
 	RETURN collect(actorsMovies {
 		.title
 	}) AS actorsMovies

--- a/core/src/test/resources/tck-test-files/cypher/sort.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/sort.adoc
@@ -136,9 +136,9 @@ query($title: String, $skip: Int, $limit: Int, $sort: [MovieSort!]) {
 [source,json]
 ----
 {
-  "limit" : 0,
-  "skip" : 0,
-  "title" : "some title"
+  "moviesLimit" : 0,
+  "moviesSkip" : 0,
+  "whereMoviesTitle" : "some title"
 }
 ----
 
@@ -146,10 +146,10 @@ query($title: String, $skip: Int, $limit: Int, $sort: [MovieSort!]) {
 [source,cypher]
 ----
 MATCH (movies:Movie)
-WHERE movies.title = $title
+WHERE movies.title = $whereMoviesTitle
 RETURN movies {
 	.title
-} AS movies ORDER BY movies.id DESC, movies.title ASC SKIP $skip LIMIT $limit
+} AS movies ORDER BY movies.id DESC, movies.title ASC SKIP $moviesSkip LIMIT $moviesLimit
 ----
 
 === Default values
@@ -294,9 +294,9 @@ query($name: String, $skip: Int, $limit: Int, $sort: [GenreSort!]) {
 [source,json]
 ----
 {
-  "limit" : 2,
-  "name" : "some name",
-  "skip" : 1
+  "moviesGenresLimit" : 2,
+  "moviesGenresSkip" : 1,
+  "whereMoviesGenresName" : "some name"
 }
 ----
 
@@ -307,8 +307,8 @@ MATCH (movies:Movie)
 CALL {
 	WITH movies
 	MATCH (movies)-[:HAS_GENRE]->(moviesGenres:Genre)
-	WHERE moviesGenres.name = $name
-	WITH moviesGenres ORDER BY moviesGenres.id DESC, moviesGenres.name ASC SKIP $skip LIMIT $limit
+	WHERE moviesGenres.name = $whereMoviesGenresName
+	WITH moviesGenres ORDER BY moviesGenres.id DESC, moviesGenres.name ASC SKIP $moviesGenresSkip LIMIT $moviesGenresLimit
 	RETURN collect(moviesGenres {
 		.name
 	}) AS moviesGenres

--- a/core/src/test/resources/tck-test-files/cypher/types/datetime.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/types/datetime.adoc
@@ -171,8 +171,8 @@ mutation {
 [source,cypher]
 ----
 CREATE (createMovie:Movie  {
-	datetime: datetime($createMovieDatetime),
-	id: $createMovieId
+	id: $createMovieId,
+	datetime: datetime($createMovieDatetime)
 })
 WITH createMovie
 RETURN createMovie {

--- a/core/src/test/resources/tck-test-files/cypher/where.adoc
+++ b/core/src/test/resources/tck-test-files/cypher/where.adoc
@@ -56,8 +56,8 @@ query($title: String, $isFavorite: Boolean) {
 [source,json]
 ----
 {
-  "isFavorite" : true,
-  "title" : "some title"
+  "whereMovieIsFavorite" : true,
+  "whereMovieTitle" : "some title"
 }
 ----
 
@@ -65,8 +65,8 @@ query($title: String, $isFavorite: Boolean) {
 [source,cypher]
 ----
 MATCH (movie:Movie)
-WHERE (movie.title = $title
-	AND movie.isFavorite = $isFavorite)
+WHERE (movie.title = $whereMovieTitle
+	AND movie.isFavorite = $whereMovieIsFavorite)
 RETURN movie {
 	.title
 } AS movie

--- a/core/src/test/resources/translator-tests1.adoc
+++ b/core/src/test/resources/translator-tests1.adoc
@@ -210,7 +210,7 @@ query getPersons($offset: Int){
 [source,json]
 ----
 {
-  "offset" : 10
+  "personOffset" : 10
 }
 ----
 
@@ -220,7 +220,7 @@ query getPersons($offset: Int){
 MATCH (person:Person)
 RETURN person {
 	.age
-} AS person SKIP $offset
+} AS person SKIP $personOffset
 ----
 
 === nested query
@@ -957,8 +957,8 @@ query {
 [source,json]
 ----
 {
-  "personLocationAnd1Longitude" : 1,
-  "personLocationAnd2Latitude" : 2
+  "personLocationAnd1Longitude" : 1.0,
+  "personLocationAnd2Latitude" : 2.0
 }
 ----
 
@@ -1003,9 +1003,9 @@ mutation{
 ----
 {
   "createPersonLocation" : {
-    "x" : 1,
-    "y" : 2,
-    "z" : 3,
+    "x" : 1.0,
+    "y" : 2.0,
+    "z" : 3.0,
     "crs" : "wgs-84-3d"
   },
   "createPersonName" : "Test2"
@@ -1030,4 +1030,48 @@ RETURN createPerson {
 		height: createPerson.location.height
 	}
 } AS createPerson
+----
+
+=== enforce typeName on interfaces
+
+.Query configuration
+[source,json,query-config=true]
+----
+{  "queryTypeOfInterfaces": true }
+----
+
+.GraphQL-Query
+[source,graphql]
+----
+{
+  location {
+    name
+    ... on City {
+      city_Arg
+    }
+    ... on Village {
+      villageArg
+    }
+  }
+}
+----
+
+.Cypher params
+[source,json]
+----
+{
+  "locationValidTypes" : [ "City", "Village" ]
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (location:Location)
+RETURN location {
+	.name,
+	.city_Arg,
+	.villageArg,
+	__typename: head([label IN labels(location) WHERE label IN $locationValidTypes])
+} AS location
 ----


### PR DESCRIPTION
With this change the way we handle projections is changed. We now rely on the graphql framework to parse fragments an arguments. This will simplify handling nested result fields like they are used in the javascript version of this library.