### PR TITLE
Remove dependency for neo4j-logging in our tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-cypher-dsl</artifactId>
-            <version>2021.4.0</version>
+            <version>2021.4.1</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.8.1</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.30</version>
+                <version>1.7.32</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/examples/dgs-spring-boot/pom.xml
+++ b/examples/dgs-spring-boot/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <testcontainers.version>1.16.2</testcontainers.version>
-        <spring-boot.version>2.5.6</spring-boot.version>
+        <spring-boot.version>2.6.1</spring-boot.version>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver-spring-boot-starter</artifactId>
-            <version>4.2.7.0</version>
+            <version>4.3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.netflix.graphql.dgs</groupId>
             <artifactId>graphql-dgs-spring-boot-starter</artifactId>
-            <version>4.8.3</version>
+            <version>4.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.netflix.graphql.dgs.codegen</groupId>

--- a/examples/graphql-spring-boot/pom.xml
+++ b/examples/graphql-spring-boot/pom.xml
@@ -15,9 +15,9 @@
     <description>Example for using neo4j-graphql-java with Spring Boot</description>
 
     <properties>
-        <testcontainers.version>1.16.0</testcontainers.version>
-        <graphql-kotlin.version>5.1.1</graphql-kotlin.version>
-        <spring-boot.version>2.3.10.RELEASE</spring-boot.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
+        <graphql-kotlin.version>5.2.0</graphql-kotlin.version>
+        <spring-boot.version>2.6.1</spring-boot.version>
     </properties>
 
     <dependencies>

--- a/neo4j-graphql-augmented-schema-generator-maven-plugin/pom.xml
+++ b/neo4j-graphql-augmented-schema-generator-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
-        <neo4j.version>4.2.4</neo4j.version>
-        <neo4j-apoc.version>4.2.0.2</neo4j-apoc.version>
-        <junit-jupiter.version>5.7.1</junit-jupiter.version>
+        <neo4j.version>4.4.1</neo4j.version>
+        <neo4j-apoc.version>4.4.0.1</neo4j-apoc.version>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
`neo4j-logging` shaded Log4j2 which is subject to CVE-2021-44228. Since we use it only in the test scope, it is safe to remove this dependency as long as all tests are still green.

resolves #260