### PR TITLE
Adding support for list type property filters

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/AugmentationHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/AugmentationHandler.kt
@@ -161,7 +161,10 @@ abstract class AugmentationHandler(
                     RelationOperator.createRelationFilterFields(type, field, filterType, builder)
                 } else {
                     FieldOperator.forType(typeDefinition, field.type.inner().isNeo4jType(), field.type.isList())
-                        .forEach { op -> builder.addFilterField(op.fieldName(field.name), op.list, filterType, field.description) }
+                        .forEach { op -> when {
+                            field.type.isList() -> builder.addArrayFilterField(op.fieldName(field.name), filterType, field.description)
+                            else -> builder.addFilterField(op.fieldName(field.name), op.list, filterType, field.description)
+                        }}
                     if (typeDefinition.isNeo4jSpatialType()) {
                         val distanceFilterType = getSpatialDistanceFilter(neo4jTypeDefinitionRegistry.getUnwrappedType(filterType) as TypeDefinition<*>)
                         FieldOperator.forType(distanceFilterType, true, field.type.isList())

--- a/core/src/main/kotlin/org/neo4j/graphql/AugmentationHandler.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/AugmentationHandler.kt
@@ -70,7 +70,7 @@ abstract class AugmentationHandler(
             if (addFieldOperations && !field.isNativeId()) {
                 val typeDefinition = field.type.resolve()
                         ?: throw IllegalArgumentException("type ${field.type.name()} cannot be resolved")
-                FieldOperator.forType(typeDefinition, field.type.inner().isNeo4jType())
+                FieldOperator.forType(typeDefinition, field.type.inner().isNeo4jType(), field.type.isList())
                     .map { op ->
                         val wrappedType: Type<*> = when {
                             op.list -> ListType(NonNullType(TypeName(type.name())))
@@ -160,11 +160,11 @@ abstract class AugmentationHandler(
                 if (field.isRelationship()) {
                     RelationOperator.createRelationFilterFields(type, field, filterType, builder)
                 } else {
-                    FieldOperator.forType(typeDefinition, field.type.inner().isNeo4jType())
+                    FieldOperator.forType(typeDefinition, field.type.inner().isNeo4jType(), field.type.isList())
                         .forEach { op -> builder.addFilterField(op.fieldName(field.name), op.list, filterType, field.description) }
                     if (typeDefinition.isNeo4jSpatialType()) {
                         val distanceFilterType = getSpatialDistanceFilter(neo4jTypeDefinitionRegistry.getUnwrappedType(filterType) as TypeDefinition<*>)
-                        FieldOperator.forType(distanceFilterType, true)
+                        FieldOperator.forType(distanceFilterType, true, field.type.isList())
                             .forEach { op -> builder.addFilterField(op.fieldName(field.name + NEO4j_POINT_DISTANCE_FILTER_SUFFIX), op.list, NEO4j_POINT_DISTANCE_FILTER) }
                     }
                 }

--- a/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -225,6 +225,17 @@ fun InputObjectTypeDefinition.Builder.addFilterField(fieldName: String, isList: 
     this.inputValueDefinition(inputField.build())
 }
 
+fun InputObjectTypeDefinition.Builder.addArrayFilterField(fieldName: String, filterType: String, description: Description? = null) {
+    val inputField = InputValueDefinition.newInputValueDefinition()
+        .name(fieldName)
+        .type(ListType(NonNullType(TypeName(filterType))))
+    if (description != null) {
+        inputField.description(description)
+    }
+
+    this.inputValueDefinition(inputField.build())
+}
+
 fun TypeDefinitionRegistry.queryTypeName() = this.getOperationType("query") ?: "Query"
 fun TypeDefinitionRegistry.mutationTypeName() = this.getOperationType("mutation") ?: "Mutation"
 fun TypeDefinitionRegistry.subscriptionTypeName() = this.getOperationType("subscription") ?: "Subscription"

--- a/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
@@ -39,10 +39,22 @@ enum class FieldOperator(
     EW("_ends_with", { lhs, rhs -> lhs.endsWith(rhs) }),
     MATCHES("_matches", { lhs, rhs -> lhs.matches(rhs) }),
 
-    EQ_LIST("", { lhs, rhs -> lhs.isEqualTo(rhs) }, list = true),
-    INCLUDES_ALL("_includes_all", { lhs, rhs -> lhs.includesAll(rhs) }, list = true),
-    INCLUDES_ANY("_includes_any", { lhs, rhs -> lhs.includesAny(rhs) }, list = true),
-    NOT_INCLUDES("_not_includes", { lhs, rhs -> lhs.includesAny(rhs).not() }, not = true, list = true),
+    INCLUDES_ALL("_includes_all", { lhs, rhs ->
+        val x: org.neo4j.cypherdsl.core.SymbolicName = org.neo4j.cypherdsl.core.Cypher.name("x")
+        org.neo4j.cypherdsl.core.Predicates.all(x).`in`(lhs).where(x.`in`(rhs))
+    }, list = true),
+    INCLUDES_SOME("_includes_some", { lhs, rhs ->
+        val x: org.neo4j.cypherdsl.core.SymbolicName = org.neo4j.cypherdsl.core.Cypher.name("x")
+        org.neo4j.cypherdsl.core.Predicates.any(x).`in`(lhs).where(x.`in`(rhs))
+    }, list = true),
+    INCLUDES_NONE("_includes_none", { lhs, rhs ->
+        val x: org.neo4j.cypherdsl.core.SymbolicName = org.neo4j.cypherdsl.core.Cypher.name("x")
+        org.neo4j.cypherdsl.core.Predicates.none(x).`in`(lhs).where(x.`in`(rhs))
+    }, list = true),
+    INCLUDES_SINGLE("_includes_single", { lhs, rhs ->
+        val x: org.neo4j.cypherdsl.core.SymbolicName = org.neo4j.cypherdsl.core.Cypher.name("x")
+        org.neo4j.cypherdsl.core.Predicates.single(x).`in`(lhs).where(x.`in`(rhs))
+    }, list = true),
 
     DISTANCE(NEO4j_POINT_DISTANCE_FILTER_SUFFIX, { lhs, rhs -> lhs.isEqualTo(rhs) }, distance = true),
     DISTANCE_LT(NEO4j_POINT_DISTANCE_FILTER_SUFFIX + "_lt", { lhs, rhs -> lhs.lt(rhs) }, distance = true),
@@ -115,7 +127,7 @@ enum class FieldOperator(
 
         fun forType(type: TypeDefinition<*>, isNeo4jType: Boolean, isList: Boolean): List<FieldOperator> =
                 when {
-                    isList -> listOf(INCLUDES_ALL, INCLUDES_ANY, NOT_INCLUDES, EQ_LIST)
+                    isList -> listOf(EQ, NEQ, INCLUDES_ALL, INCLUDES_NONE, INCLUDES_SOME, INCLUDES_SINGLE)
                     type.name == TypeBoolean.name -> listOf(EQ, NEQ)
                     type.name == NEO4j_POINT_DISTANCE_FILTER -> listOf(EQ, LT, LTE, GT, GTE)
                     type.isNeo4jSpatialType() -> listOf(EQ, NEQ)

--- a/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/Predicates.kt
@@ -39,6 +39,10 @@ enum class FieldOperator(
     EW("_ends_with", { lhs, rhs -> lhs.endsWith(rhs) }),
     MATCHES("_matches", { lhs, rhs -> lhs.matches(rhs) }),
 
+    EQ_LIST("", { lhs, rhs -> lhs.isEqualTo(rhs) }, list = true),
+    INCLUDES_ALL("_includes_all", { lhs, rhs -> lhs.includesAll(rhs) }, list = true),
+    INCLUDES_ANY("_includes_any", { lhs, rhs -> lhs.includesAny(rhs) }, list = true),
+    NOT_INCLUDES("_not_includes", { lhs, rhs -> lhs.includesAny(rhs).not() }, not = true, list = true),
 
     DISTANCE(NEO4j_POINT_DISTANCE_FILTER_SUFFIX, { lhs, rhs -> lhs.isEqualTo(rhs) }, distance = true),
     DISTANCE_LT(NEO4j_POINT_DISTANCE_FILTER_SUFFIX + "_lt", { lhs, rhs -> lhs.lt(rhs) }, distance = true),
@@ -109,8 +113,9 @@ enum class FieldOperator(
 
     companion object {
 
-        fun forType(type: TypeDefinition<*>, isNeo4jType: Boolean): List<FieldOperator> =
+        fun forType(type: TypeDefinition<*>, isNeo4jType: Boolean, isList: Boolean): List<FieldOperator> =
                 when {
+                    isList -> listOf(INCLUDES_ALL, INCLUDES_ANY, NOT_INCLUDES, EQ_LIST)
                     type.name == TypeBoolean.name -> listOf(EQ, NEQ)
                     type.name == NEO4j_POINT_DISTANCE_FILTER -> listOf(EQ, LT, LTE, GT, GTE)
                     type.isNeo4jSpatialType() -> listOf(EQ, NEQ)

--- a/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
@@ -178,6 +178,14 @@ open class ProjectionBase(
             if (value !is Map<*, *>) {
                 throw IllegalArgumentException("Only object values are supported for filtering on queried relation ${predicate.value}, but got ${value.javaClass.name}")
             }
+            if(type.isRelationType()) {
+                val targetNode = predicate.relNode.named(normalizeName(propertyContainer.requiredSymbolicName.value, predicate.relationshipInfo.typeName))
+                val relType = predicate.relationshipInfo.type
+                val parsedQuery2 = parseFilter(value, relType)
+                val condition = handleQuery(targetNode.requiredSymbolicName.value, "", targetNode, parsedQuery2, relType, variables)
+                result = result.and(condition)
+                continue
+            }
 
             val cond = name(normalizeName(variablePrefix, predicate.relationshipInfo.typeName, "Cond"))
             when (predicate.op) {

--- a/core/src/test/resources/augmentation-tests.adoc
+++ b/core/src/test/resources/augmentation-tests.adoc
@@ -9,7 +9,7 @@
 interface HasMovies { movies:[Movie] }
 type Person0 { name: String, born: _Neo4jTime, location: _Neo4jPoint }
 type Person1 { name: String, born: _Neo4jDate }
-type Person2 { name: String, age: [Int], born: _Neo4jDateTime }
+type Person2 { name: String, age: Int, born: _Neo4jDateTime }
 type Person3 { name: String!, born: _Neo4jLocalTime }
 type Person4 { id:ID!, name: String, born: _Neo4jLocalDateTime }
 type Person5 implements HasMovies { id:ID!, movies:[Movie] @relation(name: "LIKES")}
@@ -105,7 +105,7 @@ type Mutation {
   createKnows4(json: DynamicProperties, knows_id: ID!, source_id: ID!): Knows4!
   createMovie(id: ID!): Movie!
   createPerson1(born: _Neo4jDateInput, name: String): Person1!
-  createPerson2(age: [Int], born: _Neo4jDateTimeInput, name: String): Person2!
+  createPerson2(age: Int, born: _Neo4jDateTimeInput, name: String): Person2!
   createPerson3(born: _Neo4jLocalTimeInput, name: String!): Person3!
   createPerson4(born: _Neo4jLocalDateTimeInput, id: ID!, name: String): Person4!
   createPerson5(id: ID!): Person5!
@@ -146,7 +146,7 @@ type Person1 {
 }
 
 type Person2 {
-  age: [Int]
+  age: Int
   born: _Neo4jDateTime
   name: String
 }
@@ -421,7 +421,7 @@ type Person1 {
 }
 
 type Person2 {
-  age: [Int]
+  age: Int
   born: _Neo4jDateTime
   name: String
 }
@@ -454,7 +454,7 @@ type Query {
   knows4(_id: ID, filter: _Knows4Filter, first: Int, offset: Int, orderBy: [_Knows4Ordering!]): [Knows4!]!
   movie(filter: _MovieFilter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_MovieOrdering!]): [Movie!]!
   person1(born: _Neo4jDateInput, born_in: [_Neo4jDateInput!], born_not: _Neo4jDateInput, born_not_in: [_Neo4jDateInput!], filter: _Person1Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person1Ordering!]): [Person1!]!
-  person2(age: [Int], age_gt: [Int], age_gte: [Int], age_in: [Int!], age_lt: [Int], age_lte: [Int], age_not: [Int], age_not_in: [Int!], born: _Neo4jDateTimeInput, born_in: [_Neo4jDateTimeInput!], born_not: _Neo4jDateTimeInput, born_not_in: [_Neo4jDateTimeInput!], filter: _Person2Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person2Ordering!]): [Person2!]!
+  person2(age: Int, age_gt: Int, age_gte: Int, age_in: [Int!], age_lt: Int, age_lte: Int, age_not: Int, age_not_in: [Int!], born: _Neo4jDateTimeInput, born_in: [_Neo4jDateTimeInput!], born_not: _Neo4jDateTimeInput, born_not_in: [_Neo4jDateTimeInput!], filter: _Person2Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person2Ordering!]): [Person2!]!
   person3(born: _Neo4jLocalTimeInput, born_in: [_Neo4jLocalTimeInput!], born_not: _Neo4jLocalTimeInput, born_not_in: [_Neo4jLocalTimeInput!], filter: _Person3Filter, first: Int, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person3Ordering!]): [Person3!]!
   person4(born: _Neo4jLocalDateTimeInput, born_in: [_Neo4jLocalDateTimeInput!], born_not: _Neo4jLocalDateTimeInput, born_not_in: [_Neo4jLocalDateTimeInput!], filter: _Person4Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, name: String, name_contains: String, name_ends_with: String, name_gt: String, name_gte: String, name_in: [String!], name_lt: String, name_lte: String, name_matches: String, name_not: String, name_not_contains: String, name_not_ends_with: String, name_not_in: [String!], name_not_starts_with: String, name_starts_with: String, offset: Int, orderBy: [_Person4Ordering!]): [Person4!]!
   person5(filter: _Person5Filter, first: Int, id: ID, id_contains: ID, id_ends_with: ID, id_gt: ID, id_gte: ID, id_in: [ID!], id_lt: ID, id_lte: ID, id_matches: ID, id_not: ID, id_not_contains: ID, id_not_ends_with: ID, id_not_in: [ID!], id_not_starts_with: ID, id_starts_with: ID, offset: Int, orderBy: [_Person5Ordering!]): [Person5!]!
@@ -1197,7 +1197,7 @@ type Person1 {
 }
 
 type Person2 {
-  age: [Int]
+  age: Int
   born: _Neo4jDateTime
   name: String
 }

--- a/core/src/test/resources/filter-tests.adoc
+++ b/core/src/test/resources/filter-tests.adoc
@@ -15,12 +15,23 @@ type Person {
   fun: Boolean
   gender: Gender
   company: Company @relation(name:"WORKS_AT")
+  skills: [PersonSkills]
   location: _Neo4jPoint
 }
 type Company {
   _id: ID
   name: String
   employees: [Person] @relation(name:"WORKS_AT", direction: IN)
+}
+type Skill {
+  id: ID!
+  name: String
+  skilledPerson: [Person] @relation(name: "HAS_SKILL", direction: OUT)
+}
+type PersonSkills @relation(name: "HAS_SKILL", from: "person", to: "skill") {
+    person: Person
+    skill: Skill
+    proficiencyLevel: Int
 }
 ----
 
@@ -3257,6 +3268,44 @@ WHERE EXISTS {
 RETURN p {
 	.name
 } AS p
+----
+
+'''
+
+=== Filter object whose parent is relationship
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person { skills(filter: {skill: {name_starts_with: "F"}}) { skill { name } proficiencyLevel }}}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "personSkillsSkillNameStartsWith" : "F"
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+CALL {
+	WITH person
+	MATCH (person)-[personSkills:HAS_SKILL]->(personSkillsSkill:Skill)
+	WHERE personSkillsSkill.name STARTS WITH $personSkillsSkillNameStartsWith
+	RETURN collect(personSkills {
+		skill: personSkillsSkill {
+			.name
+		},
+		.proficiencyLevel
+	}) AS personSkills
+}
+RETURN person {
+	skills: personSkills
+} AS person
 ----
 
 '''

--- a/core/src/test/resources/filter-tests.adoc
+++ b/core/src/test/resources/filter-tests.adoc
@@ -13,6 +13,7 @@ type Person {
   age: Int
   height: Float
   fun: Boolean
+  hobbies: [String]
   gender: Gender
   company: Company @relation(name:"WORKS_AT")
   skills: [PersonSkills]
@@ -45,12 +46,13 @@ UNWIND [
   {id:       'jane',
    name:     'Jane',
    age:      38,
+   hobbies:  ["Cycling", "Dancing"]
    gender:   'female',
    fun:      true,
    height:   1.75,
    location: point({longitude: 1, latitude: 2, height: 3})
   },
-  {id: 'joe', name: 'Joe', age: 42, gender: 'male', fun: false, height: 1.85}
+  {id: 'joe', name: 'Joe', age: 42, hobbies: ["Reading", "Dancing"], gender: 'male', fun: false, height: 1.85}
 ] AS props
 CREATE (p:Person)-[:WORKS_AT]->(c)
 SET p = props;
@@ -61,6 +63,7 @@ UNWIND [{
   id:       'jill',
   name:     'Jill',
   age:      32,
+  hobbies:  ["Cycling", "Reading"]
   gender:   'female',
   fun:      true,
   height:   1.65,
@@ -71,6 +74,131 @@ AS props
 CREATE (p:Person)-[:WORKS_AT]->(c)
 SET p = props
 ----
+
+== Filter on _List_
+
+=== Filter on _includes_any_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies_includes_any: ["Cycling", "Reading"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+    "name" : "Joe",
+    "hobbies" : ["Reading", "Dancing"]
+  }, {
+     "name" : "Jill",
+     "hobbies" : ["Cycling", "Reading"]
+  }, {
+      "name" : "Jane",
+      "hobbies" : ["Cycling", "Dancing"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbiesIncludesAny": ["Cycling", "Reading"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE any(x IN person.hobbies
+WHERE x IN $filterPersonHobbiesIncludesAny)
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
+
+=== Filter on _includes_all_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies_includes_all: ["Cycling", "Reading"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+     "name" : "Jill",
+     "hobbies" : ["Cycling", "Reading"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbiesIncludesAll": ["Cycling", "Reading"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE all(x IN person.hobbies
+WHERE x IN $filterPersonHobbiesIncludesAll)
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
+
+=== Filter on _not_includes
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies_not_includes: ["Dancing"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+     "name" : "Jill",
+     "hobbies" : ["Cycling", "Reading"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbiesNotIncludes": ["Dancing"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE NOT (any(x IN person.hobbies
+WHERE x IN $filterPersonHobbiesNotIncludes))
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
 
 == Filter on _Enum_
 

--- a/core/src/test/resources/filter-tests.adoc
+++ b/core/src/test/resources/filter-tests.adoc
@@ -46,7 +46,7 @@ UNWIND [
   {id:       'jane',
    name:     'Jane',
    age:      38,
-   hobbies:  ["Cycling", "Dancing"]
+   hobbies:  ["Cycling", "Dancing"],
    gender:   'female',
    fun:      true,
    height:   1.75,
@@ -63,7 +63,7 @@ UNWIND [{
   id:       'jill',
   name:     'Jill',
   age:      32,
-  hobbies:  ["Cycling", "Reading"]
+  hobbies:  ["Cycling", "Reading"],
   gender:   'female',
   fun:      true,
   height:   1.65,
@@ -77,12 +77,12 @@ SET p = props
 
 == Filter on _List_
 
-=== Filter on _includes_any_
+=== Filter array _includes_some_
 
 .GraphQL-Query
 [source,graphql]
 ----
-{ person(filter: { hobbies_includes_any: ["Cycling", "Reading"] }) { name hobbies }}
+{ person(filter: { hobbies_includes_some: ["Cycling", "Reading"] }) { name hobbies }}
 ----
 
 .GraphQL-Response
@@ -105,7 +105,7 @@ SET p = props
 .Cypher Params
 [source,json]
 ----
-{"filterPersonHobbiesIncludesAny": ["Cycling", "Reading"]}
+{"filterPersonHobbiesIncludesSome": ["Cycling", "Reading"]}
 ----
 
 .Cypher
@@ -113,7 +113,7 @@ SET p = props
 ----
 MATCH (person:Person)
 WHERE any(x IN person.hobbies
-WHERE x IN $filterPersonHobbiesIncludesAny)
+WHERE x IN $filterPersonHobbiesIncludesSome)
 RETURN person {
 	.name,
 	.hobbies
@@ -122,7 +122,7 @@ RETURN person {
 
 '''
 
-=== Filter on _includes_all_
+=== Filter array _includes_all_
 
 .GraphQL-Query
 [source,graphql]
@@ -161,12 +161,12 @@ RETURN person {
 
 '''
 
-=== Filter on _not_includes
+=== Filter array _includes_none
 
 .GraphQL-Query
 [source,graphql]
 ----
-{ person(filter: { hobbies_not_includes: ["Dancing"] }) { name hobbies }}
+{ person(filter: { hobbies_includes_none: ["Dancing"] }) { name hobbies }}
 ----
 
 .GraphQL-Response
@@ -183,15 +183,136 @@ RETURN person {
 .Cypher Params
 [source,json]
 ----
-{"filterPersonHobbiesNotIncludes": ["Dancing"]}
+{"filterPersonHobbiesIncludesNone": ["Dancing"]}
 ----
 
 .Cypher
 [source,cypher]
 ----
 MATCH (person:Person)
-WHERE NOT (any(x IN person.hobbies
-WHERE x IN $filterPersonHobbiesNotIncludes))
+WHERE none(x IN person.hobbies
+WHERE x IN $filterPersonHobbiesIncludesNone)
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
+
+=== Filter array _includes_single
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies_includes_single: ["Dancing"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+    "name" : "Joe",
+    "hobbies" : ["Reading", "Dancing"]
+  }, {
+      "name" : "Jane",
+      "hobbies" : ["Cycling", "Dancing"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbiesIncludesSingle": ["Dancing"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE single(x IN person.hobbies
+WHERE x IN $filterPersonHobbiesIncludesSingle)
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
+
+=== Filter array _eq_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies: ["Cycling", "Reading"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+     "name" : "Jill",
+     "hobbies" : ["Cycling", "Reading"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbies": ["Cycling", "Reading"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE person.hobbies = $filterPersonHobbies
+RETURN person {
+	.name,
+	.hobbies
+} AS person
+----
+
+'''
+
+=== Filter array _not_
+
+.GraphQL-Query
+[source,graphql]
+----
+{ person(filter: { hobbies_not: ["Cycling", "Reading"] }) { name hobbies }}
+----
+
+.GraphQL-Response
+[source,json,response=true,ignore-order]
+----
+{
+  "person" : [ {
+    "name" : "Joe",
+    "hobbies" : ["Reading", "Dancing"]
+  }, {
+      "name" : "Jane",
+      "hobbies" : ["Cycling", "Dancing"]
+  } ]
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{"filterPersonHobbiesNot": ["Cycling", "Reading"]}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+WHERE NOT (person.hobbies = $filterPersonHobbiesNot)
 RETURN person {
 	.name,
 	.hobbies

--- a/core/src/test/resources/tck-test-files/schema/types/arrays.adoc
+++ b/core/src/test/resources/tck-test-files/schema/types/arrays.adoc
@@ -1,0 +1,116 @@
+:toc:
+
+= Schema Arrays
+
+Tests that the provided typeDefs return the correct schema.
+
+== Inputs
+
+[source,graphql,schema=true]
+----
+type Movie {
+    id: ID
+    ratings: [Float!]
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE",
+  "useWhereFilter": true,
+  "pluralizeFields": true,
+  "useTemporalScalars": true
+}
+----
+
+**Output**
+
+== Output
+
+.Augmented Schema
+[source,graphql]
+----
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Movie {
+  id: ID
+  ratings: [Float!]
+}
+
+type Mutation {
+  createMovie(id: ID, ratings: [Float!]): Movie!
+  "Deletes Movie and returns the type itself"
+  deleteMovie(id: ID): Movie
+  mergeMovie(id: ID, ratings: [Float!]): Movie!
+  updateMovie(id: ID, ratings: [Float!]): Movie
+}
+
+type Query {
+  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+}
+
+enum RelationDirection {
+  BOTH
+  IN
+  OUT
+}
+
+enum SortDirection {
+  "Sort by field values in ascending order."
+  ASC
+  "Sort by field values in descending order."
+  DESC
+}
+
+input MovieOptions {
+  "Defines the maximum amount of records returned"
+  limit: Int
+  "Defines the amount of records to be skipped"
+  skip: Int
+  "Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array."
+  sort: [MovieSort!]
+}
+
+"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object."
+input MovieSort {
+  id: SortDirection
+  ratings: SortDirection
+}
+
+input MovieWhere {
+  AND: [MovieWhere!]
+  NOT: [MovieWhere!]
+  OR: [MovieWhere!]
+  id: ID
+  id_contains: ID
+  id_ends_with: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_lt: ID
+  id_lte: ID
+  id_matches: ID
+  id_not: ID
+  id_not_contains: ID
+  id_not_ends_with: ID
+  id_not_in: [ID]
+  id_not_starts_with: ID
+  id_starts_with: ID
+  ratings: [Float!]
+  ratings_includes_all: [Float!]
+  ratings_includes_none: [Float!]
+  ratings_includes_single: [Float!]
+  ratings_includes_some: [Float!]
+  ratings_not: [Float!]
+}
+
+----
+
+'''


### PR DESCRIPTION
This PR adds support for filters which can be used with list type properties of Node or Relation.
Filters added are: `INCLUDES_ANY`, `INCLUDES_ALL`, `NOT_INCLUDES`.

This PR is in reference with the PR of cypher-dsl library (https://github.com/neo4j-contrib/cypher-dsl/pull/374) which includes enhancement for list filters in that library. 

Test cases are included for all the code changes implemented.