### PR TITLE
Fix wrong node name used for projection where on relation

### DIFF
--- a/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
+++ b/core/src/main/kotlin/org/neo4j/graphql/handler/projection/ProjectionBase.kt
@@ -179,7 +179,7 @@ open class ProjectionBase(
                 throw IllegalArgumentException("Only object values are supported for filtering on queried relation ${predicate.value}, but got ${value.javaClass.name}")
             }
             if(type.isRelationType()) {
-                val targetNode = predicate.relNode.named(normalizeName(propertyContainer.requiredSymbolicName.value, predicate.relationshipInfo.typeName))
+                val targetNode = predicate.relNode.named(normalizeName(propertyContainer.requiredSymbolicName.value, predicate.relationshipInfo.endField.capitalize()))
                 val relType = predicate.relationshipInfo.type
                 val parsedQuery2 = parseFilter(value, relType)
                 val condition = handleQuery(targetNode.requiredSymbolicName.value, "", targetNode, parsedQuery2, relType, variables)
@@ -552,7 +552,7 @@ open class ProjectionBase(
             else -> node(nodeType.name).named(childVariableName) to null
         }
 
-        val (projectionEntries, sub) = projectFields(endNodePattern, nodeType, env, name(childVariable), variableSuffix, field.selectionSet)
+        val (projectionEntries, sub) = projectFields(endNodePattern, nodeType, env, childVariableName, variableSuffix, field.selectionSet)
 
         val withPassThrough = mutableListOf(endNodePattern.requiredSymbolicName)
         var relationship = relInfo.createRelation(anyNode(variable), endNodePattern)

--- a/core/src/test/resources/issues/gh-295-wrong-target-node-alias.adoc
+++ b/core/src/test/resources/issues/gh-295-wrong-target-node-alias.adoc
@@ -1,0 +1,86 @@
+:toc:
+
+= GitHub Issue #295: Wrong node name used for end node in rich relationship
+
+== Schema
+
+[source,graphql,schema=true]
+----
+type Person{
+    name: String
+    age: Int
+    rel_has_target_book: [Person_HAS_Target_Book]
+}
+
+type Book{
+    name: String
+    price: Int
+}
+
+type Person_HAS_Target_Book @relation(name: "HAS", from: "source", to: "target", direction: OUT) {
+    name: String
+    source: Person
+    target: Book
+}
+----
+
+== Configuration
+
+.Configuration
+[source,json,schema-config=true]
+----
+{
+  "queryOptionStyle": "INPUT_TYPE",
+  "useWhereFilter": true
+}
+----
+
+== Query
+
+.GraphQL-Query
+[source,graphql]
+----
+query{
+  person{
+    name
+    rel_has_target_book(where:{name: "Foo", target:{name:"Book 1"}}){
+      target{
+        name
+      }
+    }
+  }
+}
+----
+
+.Cypher Params
+[source,json]
+----
+{
+  "personRel_has_target_bookTargetName" : "Book 1",
+  "wherePersonRel_has_target_bookName" : "Foo"
+}
+----
+
+.Cypher
+[source,cypher]
+----
+MATCH (person:Person)
+CALL {
+	WITH person
+	MATCH (person)-[personRel_has_target_book:HAS]->(personRel_has_target_bookTarget:Book)
+	WHERE (personRel_has_target_book.name = $wherePersonRel_has_target_bookName
+		AND personRel_has_target_bookTarget.name = $personRel_has_target_bookTargetName)
+	RETURN collect(personRel_has_target_book {
+		target: personRel_has_target_bookTarget {
+			.name
+		}
+	}) AS personRel_has_target_book
+}
+RETURN person {
+	.name,
+	rel_has_target_book: personRel_has_target_book
+} AS person
+----
+
+'''
+


### PR DESCRIPTION
This bugfix fixes an issue where the name of the end-node of a relation is not correctly used in the where clause

resolves #295